### PR TITLE
Removed ref option from azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,6 @@ resources:
   - repository: templates
     type: github
     name: JeringTech/DevOps.AzurePipelines
-    ref: refs/tags/0.1.0
     endpoint: JeringTech
 
 jobs:


### PR DESCRIPTION
- Just track head so that if something goes wrong we can just update the pipeline and do a manual rebuild.