### PR TITLE
Made improvements to the reliability of OutOfProcessNodeJSService

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -429,8 +429,8 @@ The next two sections list all available options.
 #### OutOfProcessNodeJSServiceOptions
 | Option | Type | Description | Default |  
 | ------ | ---- | ----------- | ------- |
-| TimeoutMS | `int` | The maximum duration to wait for the NodeJS process to initialize and to wait for responses to invocations. If set to -1, the maximum duration will be infinite. | 10000 |
-
+| TimeoutMS | `int` | The maximum duration to wait for the NodeJS process to initialize and to wait for responses to invocations. If set to a negative value, the maximum duration will be infinite. | 10000 |
+| NumRetries | `int` | The number of times an invocation will be retried. If set to a negative value, the invocation will be retried indefinitely. | 1 |
 
 ### Debugging Javascript
 These are the steps for debugging javascript invoked using INodeJSService:

--- a/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/OutOfProcessNodeJSServiceOptions.cs
+++ b/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/OutOfProcessNodeJSServiceOptions.cs
@@ -7,8 +7,14 @@
     {
         /// <summary>
         /// The maximum duration to wait for the NodeJS process to connect and to wait for responses to invocations.
-        /// If set to -1, the maximum duration will be infinite.
+        /// If set to a negative value, the maximum duration will be infinite.
         /// </summary>
         public int TimeoutMS { get; set; } = 10000;
+
+        /// <summary>
+        /// The number of times an invocation will be retried. 
+        /// If set to a negative value, the invocation will be retried indefinitely.
+        /// </summary>
+        public int NumRetries { get; set; } = 1;
     }
 }

--- a/src/NodeJS/Strings.Designer.cs
+++ b/src/NodeJS/Strings.Designer.cs
@@ -111,7 +111,7 @@ namespace Jering.Javascript.NodeJS {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Attempt to connect to Node timed out after {0}ms..
+        ///   Looks up a localized string similar to Attempt to connect to Node timed out after {0}ms. Process exited: {1}. Exit code: {2}..
         /// </summary>
         internal static string InvocationException_OutOfProcessNodeJSService_ConnectionTimedOut {
             get {
@@ -143,6 +143,17 @@ namespace Jering.Javascript.NodeJS {
         internal static string LogDebug_OutOfProcessNodeJSService_BeforeSecondSemaphore {
             get {
                 return ResourceManager.GetString("LogDebug_OutOfProcessNodeJSService_BeforeSecondSemaphore", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An invocation attempt failed. Retries remaining: {0}.
+        ///Exception:
+        ///  {1}.
+        /// </summary>
+        internal static string LogError_InvocationAttemptFailed {
+            get {
+                return ResourceManager.GetString("LogError_InvocationAttemptFailed", resourceCulture);
             }
         }
     }

--- a/src/NodeJS/Strings.resx
+++ b/src/NodeJS/Strings.resx
@@ -137,7 +137,7 @@
     <value>Received a HTTP response with an unexpected status code: {0}.</value>
   </data>
   <data name="InvocationException_OutOfProcessNodeJSService_ConnectionTimedOut" xml:space="preserve">
-    <value>Attempt to connect to Node timed out after {0}ms.</value>
+    <value>Attempt to connect to Node timed out after {0}ms. Process exited: {1}. Exit code: {2}.</value>
   </data>
   <data name="InvocationException_OutOfProcessNodeJSService_InvocationTimedOut" xml:space="preserve">
     <value>The Node invocation timed out after {0}ms. You can change the timeout duration by setting the {1} property on {2}. Do ensure that your NodeJS function always invokes the callback (or throws an exception synchronously), even if it encounters an error.</value>
@@ -147,5 +147,10 @@
   </data>
   <data name="LogDebug_OutOfProcessNodeJSService_BeforeSecondSemaphore" xml:space="preserve">
     <value>Before second semaphore wait, count: {0}. Thread ID: {1}.</value>
+  </data>
+  <data name="LogError_InvocationAttemptFailed" xml:space="preserve">
+    <value>An invocation attempt failed. Retries remaining: {0}.
+Exception:
+  {1}</value>
   </data>
 </root>

--- a/test/NodeJS.Tests/Helpers/StringBuilderLogger.cs
+++ b/test/NodeJS.Tests/Helpers/StringBuilderLogger.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Text;
+
+namespace Jering.Javascript.NodeJS.Tests
+{
+    public class StringBuilderLogger : ILogger
+    {
+        private readonly StringBuilder _stringBuilder;
+
+        public StringBuilderLogger(StringBuilder stringBuilder)
+        {
+            _stringBuilder = stringBuilder;
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            _stringBuilder.AppendLine(formatter(state, exception));
+        }
+    }
+}

--- a/test/NodeJS.Tests/Helpers/StringBuilderProvider.cs
+++ b/test/NodeJS.Tests/Helpers/StringBuilderProvider.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.Logging;
+using System.Text;
+
+namespace Jering.Javascript.NodeJS.Tests
+{
+    public class StringBuilderProvider : ILoggerProvider
+    {
+        private readonly StringBuilder _stringBuilder;
+
+        public StringBuilderProvider(StringBuilder stringBuilder)
+        {
+            _stringBuilder = stringBuilder;
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new StringBuilderLogger(_stringBuilder);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/test/NodeJS.Tests/HttpNodeJSServiceIntegrationTests.cs
+++ b/test/NodeJS.Tests/HttpNodeJSServiceIntegrationTests.cs
@@ -250,10 +250,9 @@ namespace Jering.Javascript.NodeJS.Tests
         }
 
         /// <summary>
-        /// Specify <paramref name="stringLoggerStringBuilder"/> to retrieve all log output.
+        /// Specify <paramref name="loggerStringBuilder"/> for access to all logging output.
         /// </summary>
-        /// <param name="stringLoggerStringBuilder"></param>
-        private HttpNodeJSService CreateHttpNodeService(StringBuilder stringLoggerStringBuilder = null)
+        private HttpNodeJSService CreateHttpNodeService(StringBuilder loggerStringBuilder = null)
         {
             var services = new ServiceCollection();
             services.AddNodeJS(); // Default INodeService is HttpNodeService
@@ -263,11 +262,11 @@ namespace Jering.Javascript.NodeJS.Tests
                     AddProvider(new TestOutputProvider(_testOutputHelper)).
                     AddFilter<TestOutputProvider>((LogLevel loglevel) => loglevel >= LogLevel.Debug);
 
-                if (stringLoggerStringBuilder != null)
+                if (loggerStringBuilder != null)
                 {
                     lb.
-                        AddProvider(new StringLoggerProvider(stringLoggerStringBuilder)).
-                        AddFilter<StringLoggerProvider>((LogLevel LogLevel) => LogLevel >= LogLevel.Information);
+                        AddProvider(new StringBuilderProvider(loggerStringBuilder)).
+                        AddFilter<StringBuilderProvider>((LogLevel LogLevel) => LogLevel >= LogLevel.Information);
                 }
             });
 
@@ -280,52 +279,6 @@ namespace Jering.Javascript.NodeJS.Tests
             _serviceProvider = services.BuildServiceProvider();
 
             return _serviceProvider.GetRequiredService<INodeJSService>() as HttpNodeJSService;
-        }
-
-        // Used by AllInvokeMethods_ReceiveAndLogMessages to validate output from the NodeJS process
-        public class StringLogger : ILogger
-        {
-            private readonly StringBuilder _stringBuilder;
-
-            public StringLogger(StringBuilder stringBuilder)
-            {
-                _stringBuilder = stringBuilder;
-            }
-
-            public IDisposable BeginScope<TState>(TState state)
-            {
-                return null;
-            }
-
-            public bool IsEnabled(LogLevel logLevel)
-            {
-                return true;
-            }
-
-            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
-            {
-                _stringBuilder.AppendLine(formatter(state, exception));
-            }
-        }
-
-        // Used by AllInvokeMethods_ReceiveAndLogMessages to validate output from the NodeJS process
-        public class StringLoggerProvider : ILoggerProvider
-        {
-            private readonly StringBuilder _stringBuilder;
-
-            public StringLoggerProvider(StringBuilder stringBuilder)
-            {
-                _stringBuilder = stringBuilder;
-            }
-
-            public ILogger CreateLogger(string categoryName)
-            {
-                return new StringLogger(_stringBuilder);
-            }
-
-            public void Dispose()
-            {
-            }
         }
 
         private class DummyResult


### PR DESCRIPTION
- Placed _nodeProcess manipulations within lock blocks to avoid InvalidOperationExceptions thrown when accessing some Process properties after disposal.
- Added retries for invocations.
- Improved exception message for failed node connections.
- Minor improvments to tests.
- Updated documentation.