### PR TITLE
Lockfree round robin

### DIFF
--- a/perf/NodeJS/PoolThreadingBenchmarks.cs
+++ b/perf/NodeJS/PoolThreadingBenchmarks.cs
@@ -1,0 +1,123 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jering.Javascript.NodeJS.Performance
+{
+    // Benchmarks for threading methods considered for HttpNodeJSPoolServices
+    [MemoryDiagnoser]
+    public class PoolThreadingBenchmarks
+    {
+        private LockFreeMethod _lockFree;
+        private LockMethod _lock;
+
+        private IEnumerable<int> _source = Enumerable.Range(0, 2000);
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _lock = new LockMethod();
+            _lockFree = new LockFreeMethod();
+
+            // Keep benchmarks consistent
+            ThreadPool.SetMinThreads(Environment.ProcessorCount, Environment.ProcessorCount);
+            ThreadPool.SetMaxThreads(Environment.ProcessorCount, Environment.ProcessorCount);
+        }
+
+        [Benchmark]
+        public void Lock()
+        {
+            _lock.GetDummyObject();
+        }
+
+        [Benchmark]
+        public void LockFree()
+        {
+            _lockFree.GetDummyObject();
+        }
+
+        [Benchmark]
+        public void LockFree_Parallel()
+        {
+            Parallel.ForEach(_source, LockFree_GetDummyObject);
+        }
+
+        private void LockFree_GetDummyObject(int _)
+        {
+            _lockFree.GetDummyObject();
+        }
+
+        [Benchmark]
+        public void Lock_Parallel()
+        {
+            Parallel.ForEach(_source, Lock_GetDummyObject);
+        }
+
+        private void Lock_GetDummyObject(int _)
+        {
+            _lock.GetDummyObject();
+        }
+
+        private class LockMethod
+        {
+            private readonly ReadOnlyCollection<object> _dummyObjects;
+
+            private readonly int _maxIndex;
+            private readonly object _dummyObjectsLock = new object();
+            private int _nextIndex;
+
+            public int Size { get; }
+
+            public LockMethod()
+            {
+                var dummyObjects = new ReadOnlyCollection<object>(Enumerable.Range(0, 16).Select(x => new object()).ToList());
+
+                _dummyObjects = dummyObjects;
+                Size = dummyObjects.Count;
+                _maxIndex = Size - 1;
+            }
+
+            internal object GetDummyObject()
+            {
+                int index = 0;
+                lock (_dummyObjectsLock)
+                {
+                    if (_nextIndex > _maxIndex)
+                    {
+                        _nextIndex = 0;
+                    }
+
+                    index = _nextIndex++;
+                }
+
+                return _dummyObjects[index];
+            }
+        }
+
+        private class LockFreeMethod
+        {
+            private readonly ReadOnlyCollection<object> _dummyObjects;
+            private int _nextIndex;
+
+            public int Size { get; }
+
+            public LockFreeMethod()
+            {
+                var dummyObjects = new ReadOnlyCollection<object>(Enumerable.Range(0, 16).Select(x => new object()).ToList());
+
+                _dummyObjects = dummyObjects;
+                Size = dummyObjects.Count;
+            }
+
+            internal object GetDummyObject()
+            {
+                uint index = unchecked((uint)Interlocked.Increment(ref _nextIndex));
+                return _dummyObjects[(int)(index % Size)];
+            }
+        }
+    }
+}

--- a/perf/NodeJS/Program.cs
+++ b/perf/NodeJS/Program.cs
@@ -9,6 +9,7 @@ namespace Jering.Javascript.NodeJS.Performance
             BenchmarkRunner.Run<LatencyBenchmarks>();
             BenchmarkRunner.Run<ConcurrencyBenchmarks>();
             BenchmarkRunner.Run<RealWorkloadBenchmarks>();
+            BenchmarkRunner.Run<PoolThreadingBenchmarks>();
         }
     }
 }

--- a/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpNodeJSPoolService.cs
+++ b/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpNodeJSPoolService.cs
@@ -14,7 +14,8 @@ namespace Jering.Javascript.NodeJS
         private readonly ReadOnlyCollection<HttpNodeJSService> _httpNodeJSServices;
 
         private bool _disposed;
-        private volatile int _nextIndex = -1;
+        // Does not need to be volatile since Interlocked.Increment has ordering guarantees
+        private int _nextIndex;
 
         /// <summary>
         /// Gets the size of the <see cref="HttpNodeJSPoolService"/>.
@@ -104,6 +105,12 @@ namespace Jering.Javascript.NodeJS
 
         internal HttpNodeJSService GetHttpNodeJSService()
         {
+            // Notes
+            // - Interlocked.Increment wraps. This means if _nextIndex == Int32.MaxValue, it is set to Int32.MinValue - https://docs.microsoft.com/en-us/dotnet/api/system.threading.interlocked.increment?view=netstandard-2.0.
+            // - unchecked((uint)number) means the bits representing the int are interpreted as uint - https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/numeric-conversions.
+            // - Since .Net uses 2's complement to represent negative numbers, this means unchecked((uint)-1) == 4294967295 (UInt32.MaxValue), unchecked((uint)-2) == 4294967294 (UInt32.MaxValue - 1) and so on.
+            // - This method will not return each HttpNodeJSService the same number of times when UInt32.MaxValue isn't divisible by Size. However, so long as between the 4 billion plus calls there is enough
+            //   downtime for the NodeJS processes with extra invocations to complete them and catch up, we should be fine.
             uint index = unchecked((uint)Interlocked.Increment(ref _nextIndex));
             return _httpNodeJSServices[(int)(index % Size)];
         }

--- a/test/NodeJS/HttpNodeJSPoolServiceUnitTests.cs
+++ b/test/NodeJS/HttpNodeJSPoolServiceUnitTests.cs
@@ -18,6 +18,7 @@ namespace Jering.Javascript.NodeJS.Tests
     // - Ensure INodeJSService member implementations call the right method on the returned HttpNodeJSService.
     public class HttpNodeJSPoolServiceUnitTests
     {
+        private const int TIMEOUT_MS = 60000;
         private readonly MockRepository _mockRepository = new MockRepository(MockBehavior.Default);
 
         [Fact]
@@ -293,7 +294,7 @@ namespace Jering.Javascript.NodeJS.Tests
             _mockRepository.VerifyAll();
         }
 
-        [Fact]
+        [Fact(Timeout = TIMEOUT_MS)]
         public void GetHttpNodeJSService_ReturnsEachHttpNodeJSServiceAnEqualNumberOfTimes()
         {
             // Arrange


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.17763.475 (1809/October2018Update/Redstone5)
Intel Core i7-7700 CPU 3.60GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100
  [Host]     : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), X64 RyuJIT
  DefaultJob : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), X64 RyuJIT


```
|           Method |          Mean |        Error |        StdDev |        Median |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
|----------------- |--------------:|-------------:|--------------:|--------------:|--------:|-------:|------:|----------:|
|             Lock |      17.24 ns |     0.146 ns |      0.136 ns |      17.29 ns |       - |      - |     - |         - |
|         LockFree |      16.10 ns |     0.021 ns |      0.017 ns |      16.11 ns |       - |      - |     - |         - |
|     LockParallel | 263,920.42 ns | 8,655.977 ns | 25,522.345 ns | 272,410.38 ns | 18.0664 | 0.2441 |     - |   62901 B |
| LockFreeParallel |  73,642.52 ns |   311.213 ns |    275.882 ns |  73,615.78 ns |  8.4229 | 0.1221 |     - |   28947 B |


Benchmark code
```
using System;
using System.Collections.ObjectModel;
using System.Linq;
using System.Threading;
using System.Threading.Tasks;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

namespace ConsoleApp1
{
    class Program
    {
        static void Main(string[] args)
        {
            BenchmarkRunner.Run<Benchmarks>();
        }
    }

    public class Lock
    {
        private readonly ReadOnlyCollection<object> _httpNodeJSServices;

        private readonly int _maxIndex;
        private readonly object _httpNodeJSServicesLock = new object();
        private int _nextIndex;

        public int Size { get; }

        public Lock()
        {
            var httpNodeJSServices = new ReadOnlyCollection<object>(Enumerable.Range(0, 16).Select(x => new object()).ToList());

            _httpNodeJSServices = httpNodeJSServices;
            Size = httpNodeJSServices.Count;
            _maxIndex = Size - 1;
        }


        internal object GetHttpNodeJSService()
        {
            int index = 0;
            lock (_httpNodeJSServicesLock)
            {
                if (_nextIndex > _maxIndex)
                {
                    _nextIndex = 0;
                }

                index = _nextIndex++;
            }

            return _httpNodeJSServices[index];
        }
    }

    public class LockFree
    {
        private readonly ReadOnlyCollection<object> _httpNodeJSServices;
        private volatile int _nextIndex = -1;

        public int Size { get; }

        public LockFree()
        {
            var httpNodeJSServices = new ReadOnlyCollection<object>(Enumerable.Range(0, 16).Select(x => new object()).ToList());

            _httpNodeJSServices = httpNodeJSServices;
            Size = httpNodeJSServices.Count;
        }

        internal object GetHttpNodeJSService()
        {
            uint index = unchecked((uint)Interlocked.Increment(ref _nextIndex));
            return _httpNodeJSServices[(int)(index % Size)];
        }
    }

    [MemoryDiagnoser]
    public class Benchmarks
    {
        private LockFree _lockFree;
        private Lock _lock;

        [GlobalSetup]
        public void Setup()
        {
            _lock = new Lock();
            _lockFree = new LockFree();
        }

        [Benchmark]
        public void Lock()
        {
            _lock.GetHttpNodeJSService();
        }
        
        [Benchmark]
        public void LockFree()
        {
            _lockFree.GetHttpNodeJSService();
        }

        [Benchmark]
        public void LockParallel()
        {
            Parallel.ForEach(
                Enumerable.Range(0, 2000),
                new ParallelOptions { MaxDegreeOfParallelism = 32 },
                _ => _lock.GetHttpNodeJSService()
            );
        }

        [Benchmark]
        public void LockFreeParallel()
        {
            Parallel.ForEach(
                Enumerable.Range(0, 2000),
                new ParallelOptions { MaxDegreeOfParallelism = 32 },
                _ => _lockFree.GetHttpNodeJSService()
            );
        }
    }
}

```