### PR TITLE
capture the final output from node processes to help diagnose unexpected node exits

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,11 @@ This project uses [semantic versioning](http://semver.org/spec/v2.0.0.html). Ref
 *[Semantic Versioning in Practice](https://www.jering.tech/articles/semantic-versioning-in-practice)*
 for an overview of semantic versioning.
 
-## [Unreleased](https://github.com/JeringTech/Javascript.NodeJS/compare/5.4.0...HEAD)
+## [Unreleased](https://github.com/JeringTech/Javascript.NodeJS/compare/5.4.1...HEAD)
+
+## [5.4.1](https://github.com/JeringTech/Javascript.NodeJS/compare/5.4.0...5.4.1) - Jun 23, 2020
+### Fixes
+- Fixed capturing of final output from Node.js. ([#84](https://github.com/JeringTech/Javascript.NodeJS/pull/84)).
 
 ## [5.4.0](https://github.com/JeringTech/Javascript.NodeJS/compare/5.3.2...5.4.0) - Mar 9, 2020
 ### Additions

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1029,6 +1029,7 @@ Contributions are welcome!
 - [JeremyTCD](https://github.com/JeremyTCD)
 - [Daniil Sokolyuk](https://github.com/DaniilSokolyuk)
 - [dustinsoftware](https://github.com/dustinsoftware)
+- [blushingpenguin](https://github.com/blushingpenguin)
 
 ## About
 Follow [@JeringTech](https://twitter.com/JeringTech) for updates and more.

--- a/test/NodeJS/NodeJSProcessUnitTests.cs
+++ b/test/NodeJS/NodeJSProcessUnitTests.cs
@@ -240,18 +240,40 @@ namespace Jering.Javascript.NodeJS.Tests
         }
 
         [Fact]
-        public void DataReceivedHandler_DoesNothingIfEventDataIsNull()
+        public void DataReceivedHandler_DoesNothingIfEventDataIsNullAndThereIsNoBufferedData()
         {
             // Arrange
             Mock<NodeJSProcess> mockTestSubject = CreateMockNodeJSProcess();
             mockTestSubject.CallBase = true;
 
             // Act
-            mockTestSubject.Object.DataReceivedHandler(null, null, null, CreateDataReceivedEventArgs());
+            var sb = new StringBuilder();
+            string capturedMessage = "__NOTCALLED__";
+            mockTestSubject.Object.DataReceivedHandler(sb, (object sender, string message) => capturedMessage = message, null, CreateDataReceivedEventArgs());
 
             // Assert
             string dummyOutMessage = null;
-            mockTestSubject.Verify(t => t.TryCreateMessage(It.IsAny<StringBuilder>(), It.IsAny<string>(), out dummyOutMessage), Times.Never());
+            mockTestSubject.Verify(t => t.TryCreateMessage(It.IsAny<StringBuilder>(), It.IsAny<string>(), out dummyOutMessage), Times.Once());
+            Assert.Equal("__NOTCALLED__", capturedMessage);
+        }
+
+        [Fact]
+        public void DataReceivedHandler_SendsBufferedDataIfEventDataIsNull()
+        {
+            // Arrange
+            Mock<NodeJSProcess> mockTestSubject = CreateMockNodeJSProcess();
+            mockTestSubject.CallBase = true;
+
+            // Act
+            var sb = new StringBuilder();
+            sb.Append("test message");
+            string capturedMessage = null;
+            mockTestSubject.Object.DataReceivedHandler(sb, (object sender, string message) => capturedMessage = message, null, CreateDataReceivedEventArgs());
+
+            // Assert
+            string dummyOutMessage = null;
+            mockTestSubject.Verify(t => t.TryCreateMessage(It.IsAny<StringBuilder>(), It.IsAny<string>(), out dummyOutMessage), Times.Once());
+            Assert.Equal("test message", capturedMessage);
         }
 
         [Fact]


### PR DESCRIPTION
This should help with #60 - for example I now get something like the output below when node runs out of heap.

```
2020-06-23 12:10:38.815 +00:00 [Information] Jering.Javascript.NodeJS.HttpNodeJSService:
<--- Last few GCs --->

[56928:00000203B5E6B670]     7425 ms: Scavenge 501.7 (510.4) -> 501.5 (511.1) MB, 3.4 / 0.0 ms  (average mu = 0.090, current mu = 0.060) allocation failure
[56928:00000203B5E6B670]     7432 ms: Scavenge 502.4 (511.1) -> 502.3 (516.9) MB, 4.5 / 0.0 ms  (average mu = 0.090, current mu = 0.060) allocation failure


<--- JS stacktrace --->

==== JS stack trace =========================================

    0: ExitFrame [pc: 00007FF6F67A6C4D]
    1: StubFrame [pc: 00007FF6F67A7B7D]
    2: StubFrame [pc: 00007FF6F67EB7C1]
Security context: 0x03740c9008d1 <JSObject>
    3: repeat [000003740C9163A1](this=0x00df02b87969 <String[#1]: a>,1048576)
    4: appReceived [000001AB9679FD71] [C:\dev\Vendeq.Integrations.Api\Vendeq.Integrations.Jobs.Generic\vendeq.js:~37] [pc=0000033B848D041D](this=0x01ab9679fe01 <JSRunner map = 000002A2CE827949>,0x01ab...


2020-06-23 12:10:38.815 +00:00 [Error] Jering.Javascript.NodeJS.HttpNodeJSService: FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory

Writing Node.js report to file: report.20200623.131038.56928.0.001.json
Node.js report completed
 1: 00007FF6F5B9D1EF napi_wrap+113103
 2: 00007FF6F5B3CA66 public: bool __cdecl v8::base::CPU::has_sse(void)const __ptr64+64982
 3: 00007FF6F5B3D8F3 public: bool __cdecl v8::base::CPU::has_sse(void)const __ptr64+68707
 4: 00007FF6F6359BBE private: void __cdecl v8::Isolate::ReportExternalAllocationLimitReached(void) __ptr64+94
 5: 00007FF6F6341C91 public: class v8::SharedArrayBuffer::Contents __cdecl v8::SharedArrayBuffer::Externalize(void) __ptr64+833
 6: 00007FF6F620E1EC public: static void __cdecl v8::internal::Heap::EphemeronKeyWriteBarrierFromCode(unsigned __int64,unsigned __int64,class v8::internal::Isolate * __ptr64)+1436
 7: 00007FF6F6219420 public: void __cdecl v8::internal::Heap::ProtectUnprotectedMemoryChunks(void) __ptr64+1312
 8: 00007FF6F6215F44 public: static bool __cdecl v8::internal::Heap::PageFlagsAreConsistent(class v8::internal::HeapObject)+3204
 9: 00007FF6F620B743 public: bool __cdecl v8::internal::Heap::CollectGarbage(enum v8::internal::AllocationSpace,enum v8::internal::GarbageCollectionReason,enum v8::GCCallbackFlags) __ptr64+1283
10: 00007FF6F6209DB4 public: void __cdecl v8::internal::Heap::AddRetainedMap(class v8::internal::Handle<class v8::internal::Map>) __ptr64+2452
11: 00007FF6F622AFBD public: class v8::internal::Handle<class v8::internal::HeapObject> __cdecl v8::internal::Factory::NewFillerObject(int,bool,enum v8::internal::AllocationType,enum v8::internal::AllocationOrigin) __ptr64+61
12: 00007FF6F5F91871 public: class v8::internal::interpreter::JumpTableTargetOffsets::iterator & __ptr64 __cdecl v8::internal::interpreter::JumpTableTargetOffsets::iterator::operator=(class v8::internal::interpreter::JumpTableTargetOffsets::iterator && __ptr64) __ptr64+1665
13: 00007FF6F67A6C4D public: virtual bool __cdecl v8::internal::SetupIsolateDelegate::SetupHeap(class v8::internal::Heap * __ptr64) __ptr64+546637
14: 00007FF6F67A7B7D public: virtual bool __cdecl v8::internal::SetupIsolateDelegate::SetupHeap(class v8::internal::Heap * __ptr64) __ptr64+550525
15: 00007FF6F67EB7C1 public: virtual bool __cdecl v8::internal::SetupIsolateDelegate::SetupHeap(class v8::internal::Heap * __ptr64) __ptr64+828097
16: 00007FF6F67EB8E9 public: virtual bool __cdecl v8::internal::SetupIsolateDelegate::SetupHeap(class v8::internal::Heap * __ptr64) __ptr64+828393
17: 0000033B848D041D
```