### PR TITLE
disable keep alive timeout, headers timeout and log any server timeouts

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,11 @@ This project uses [semantic versioning](http://semver.org/spec/v2.0.0.html). Ref
 *[Semantic Versioning in Practice](https://www.jering.tech/articles/semantic-versioning-in-practice)*
 for an overview of semantic versioning.
 
-## [Unreleased](https://github.com/JeringTech/Javascript.NodeJS/compare/5.4.1...HEAD)
+## [Unreleased](https://github.com/JeringTech/Javascript.NodeJS/compare/5.4.2...HEAD)
+
+## [5.4.2](https://github.com/JeringTech/Javascript.NodeJS/compare/5.4.1...5.4.2) - Jun 25, 2020
+### Fixes
+- Disabled unecessary Node.js HTTP timeouts, added logging for timeouts. ([#85](https://github.com/JeringTech/Javascript.NodeJS/pull/85)).
 
 ## [5.4.1](https://github.com/JeringTech/Javascript.NodeJS/compare/5.4.0...5.4.1) - Jun 23, 2020
 ### Fixes


### PR DESCRIPTION
This cures my issue with randomly aborted connections (https://github.com/JeringTech/Javascript.NodeJS/issues/60).  I tried to write a test for this, but it's actually hard to reproduce -- the easiest way to elicit this was to debug the node process while making multiple concurrent connections to it.

I think what's happening is that you get a .NET connection pooled, connected http connection which node then closes when data is sent to it as in:

https://github.com/nodejs/node/issues/26165

also as per this PR:

https://github.com/nodejs/node/pull/33307

the headers timeout cannot be disabled (but it can be set to a very long value, which is what I've done).  I also disabled the keepalive timeout for sockets as that's another possible reason that node is dropping the pooled connections.


