### PR TITLE
Improve robustness

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,15 @@ This project uses [semantic versioning](http://semver.org/spec/v2.0.0.html). Ref
 *[Semantic Versioning in Practice](https://www.jering.tech/articles/semantic-versioning-in-practice)*
 for an overview of semantic versioning.
 
-## [Unreleased](https://github.com/JeringTech/Javascript.NodeJS/compare/6.0.0-beta.1...HEAD)
+## [Unreleased](https://github.com/JeringTech/Javascript.NodeJS/compare/6.0.0-beta.2...HEAD)
+
+## [6.0.0-beta.2](https://github.com/JeringTech/Javascript.NodeJS/compare/6.0.0-beta.1...6.0.0-beta.2) - Feb 24, 2021
+### Additions
+- Added `OutOfProcessNodeJSServiceOptions.NumProcessRetries` option. ([#101](https://github.com/JeringTech/Javascript.NodeJS/pull/101).
+### Changes
+- `HttpNodeJSService` now logs endpoint on connect. Logged at `information` level. ([#101](https://github.com/JeringTech/Javascript.NodeJS/pull/101)).
+- **Breaking**: Renamed `OutOfProcessNodeJSServiceOptions.WatchGracefulShutdown` to `GracefulProcessShutdown`. Option now affects
+process shutdowns on-file-change *and* when retrying invocations. ([#101](https://github.com/JeringTech/Javascript.NodeJS/pull/101)).
 
 ## [6.0.0-beta.1](https://github.com/JeringTech/Javascript.NodeJS/compare/6.0.0-beta.0...6.0.0-beta.1) - Feb 22, 2021
 ### Fixes

--- a/perf/NodeJS/ConcurrencyBenchmarks.cs
+++ b/perf/NodeJS/ConcurrencyBenchmarks.cs
@@ -13,7 +13,7 @@ namespace Jering.Javascript.NodeJS.Performance
     {
         private const string DUMMY_WARMUP_MODULE = "module.exports = (callback) => callback()";
         private const string DUMMY_CONCURRENCY_MODULE_FILE = "dummyConcurrencyModule.js";
-        private static readonly string PROJECT_PATH = Path.Combine(Directory.GetCurrentDirectory(), "../../../../../../../Javascript");  // BenchmarkDotNet creates a project nested deep in bin
+        private static readonly string _projectPath = Path.Combine(Directory.GetCurrentDirectory(), "../../../../../../../Javascript");  // BenchmarkDotNet creates a project nested deep in bin
 
         private ServiceProvider _serviceProvider;
         private INodeJSService _nodeJSService;
@@ -25,7 +25,7 @@ namespace Jering.Javascript.NodeJS.Performance
         {
             var services = new ServiceCollection();
             services.AddNodeJS();
-            services.Configure<NodeJSProcessOptions>(options => options.ProjectPath = PROJECT_PATH);
+            services.Configure<NodeJSProcessOptions>(options => options.ProjectPath = _projectPath);
             services.Configure<OutOfProcessNodeJSServiceOptions>(options => options.Concurrency = Concurrency.MultiProcess);
             _serviceProvider = services.BuildServiceProvider();
             _nodeJSService = _serviceProvider.GetRequiredService<INodeJSService>();
@@ -57,7 +57,7 @@ namespace Jering.Javascript.NodeJS.Performance
         {
             var services = new ServiceCollection();
             services.AddNodeJS();
-            services.Configure<NodeJSProcessOptions>(options => options.ProjectPath = PROJECT_PATH);
+            services.Configure<NodeJSProcessOptions>(options => options.ProjectPath = _projectPath);
             _serviceProvider = services.BuildServiceProvider();
             _nodeJSService = _serviceProvider.GetRequiredService<INodeJSService>();
 
@@ -86,7 +86,7 @@ namespace Jering.Javascript.NodeJS.Performance
             var services = new ServiceCollection();
             services.AddNodeServices(options =>
             {
-                options.ProjectPath = PROJECT_PATH;
+                options.ProjectPath = _projectPath;
                 options.WatchFileExtensions = null;
             });
             _serviceProvider = services.BuildServiceProvider();

--- a/perf/NodeJS/FileWatchingBenchmarks.cs
+++ b/perf/NodeJS/FileWatchingBenchmarks.cs
@@ -40,7 +40,7 @@ namespace Jering.Javascript.NodeJS.Performance
             services.Configure<OutOfProcessNodeJSServiceOptions>(options =>
             {
                 options.EnableFileWatching = true;
-                options.WatchGracefulShutdown = false;
+                options.GracefulProcessShutdown = false;
             });
             _serviceProvider = services.BuildServiceProvider();
             _httpNodeJSService = _serviceProvider.GetRequiredService<INodeJSService>() as HttpNodeJSService;

--- a/perf/NodeJS/LatencyBenchmarks.cs
+++ b/perf/NodeJS/LatencyBenchmarks.cs
@@ -14,7 +14,7 @@ namespace Jering.Javascript.NodeJS.Performance
         private const string DUMMY_WARMUP_MODULE = "module.exports = (callback) => callback()";
         private const string DUMMY_LATENCY_MODULE_FILE = "dummyLatencyModule.js";
         private const string DUMMY_MODULE_IDENTIFIER = "dummyLatencyModuleIdentifier";
-        private static readonly string PROJECT_PATH = Path.Combine(Directory.GetCurrentDirectory(), "../../../../../../../Javascript"); // BenchmarkDotNet creates a project nested deep in bin
+        private static readonly string _projectPath = Path.Combine(Directory.GetCurrentDirectory(), "../../../../../../../Javascript"); // BenchmarkDotNet creates a project nested deep in bin
 
         private ServiceProvider _serviceProvider;
         private int _counter;
@@ -27,7 +27,7 @@ namespace Jering.Javascript.NodeJS.Performance
         {
             var services = new ServiceCollection();
             services.AddNodeJS();
-            services.Configure<NodeJSProcessOptions>(options => options.ProjectPath = PROJECT_PATH);
+            services.Configure<NodeJSProcessOptions>(options => options.ProjectPath = _projectPath);
             _serviceProvider = services.BuildServiceProvider();
             _nodeJSService = _serviceProvider.GetRequiredService<INodeJSService>();
             _counter = 0;
@@ -50,7 +50,7 @@ namespace Jering.Javascript.NodeJS.Performance
         {
             var services = new ServiceCollection();
             services.AddNodeJS();
-            services.Configure<NodeJSProcessOptions>(options => options.ProjectPath = PROJECT_PATH);
+            services.Configure<NodeJSProcessOptions>(options => options.ProjectPath = _projectPath);
             services.Configure<OutOfProcessNodeJSServiceOptions>(options => options.EnableFileWatching = true);
             _serviceProvider = services.BuildServiceProvider();
             _nodeJSService = _serviceProvider.GetRequiredService<INodeJSService>();
@@ -87,7 +87,7 @@ namespace Jering.Javascript.NodeJS.Performance
 
         private string DummyModuleFactory()
         {
-            return File.ReadAllText(Path.Combine(PROJECT_PATH, DUMMY_LATENCY_MODULE_FILE));
+            return File.ReadAllText(Path.Combine(_projectPath, DUMMY_LATENCY_MODULE_FILE));
         }
 
         [Obsolete]
@@ -97,7 +97,7 @@ namespace Jering.Javascript.NodeJS.Performance
             var services = new ServiceCollection();
             services.AddNodeServices(options =>
             {
-                options.ProjectPath = PROJECT_PATH;
+                options.ProjectPath = _projectPath;
                 options.WatchFileExtensions = null;
             });
             _serviceProvider = services.BuildServiceProvider();

--- a/perf/NodeJS/RealWorkloadBenchmarks.cs
+++ b/perf/NodeJS/RealWorkloadBenchmarks.cs
@@ -22,7 +22,7 @@ namespace Jering.Javascript.NodeJS.Performance
         Console.WriteLine(""Hello world {0}!"");
     }}
 }}";
-        private static readonly string PROJECT_PATH = Path.Combine(Directory.GetCurrentDirectory(), "../../../../../../../Javascript"); // BenchmarkDotNet creates a project nested deep in bin
+        private static readonly string _projectPath = Path.Combine(Directory.GetCurrentDirectory(), "../../../../../../../Javascript"); // BenchmarkDotNet creates a project nested deep in bin
 
         private int _counter;
         private ServiceProvider _serviceProvider;
@@ -35,7 +35,7 @@ namespace Jering.Javascript.NodeJS.Performance
         {
             var services = new ServiceCollection();
             services.AddNodeJS();
-            services.Configure<NodeJSProcessOptions>(options => options.ProjectPath = PROJECT_PATH); // Module loads prismjs from node_modules
+            services.Configure<NodeJSProcessOptions>(options => options.ProjectPath = _projectPath); // Module loads prismjs from node_modules
             services.Configure<OutOfProcessNodeJSServiceOptions>(options => options.Concurrency = Concurrency.MultiProcess);
             _serviceProvider = services.BuildServiceProvider();
             _nodeJSService = _serviceProvider.GetRequiredService<INodeJSService>();
@@ -66,7 +66,7 @@ namespace Jering.Javascript.NodeJS.Performance
 
         private string DummyModuleFactory()
         {
-            return File.ReadAllText(Path.Combine(PROJECT_PATH, DUMMY_REAL_WORKLOAD_MODULE_FILE));
+            return File.ReadAllText(Path.Combine(_projectPath, DUMMY_REAL_WORKLOAD_MODULE_FILE));
         }
 
         [Obsolete]
@@ -76,7 +76,7 @@ namespace Jering.Javascript.NodeJS.Performance
             var services = new ServiceCollection();
             services.AddNodeServices(options =>
             {
-                options.ProjectPath = PROJECT_PATH;
+                options.ProjectPath = _projectPath;
                 options.WatchFileExtensions = null;
             });
             _serviceProvider = services.BuildServiceProvider();

--- a/src/NodeJS/Jering.Javascript.NodeJS.csproj
+++ b/src/NodeJS/Jering.Javascript.NodeJS.csproj
@@ -6,7 +6,7 @@
         <PackageId>Jering.Javascript.NodeJS</PackageId>
         <Authors>JeremyTCD</Authors>
         <Title>Invoke Javascript in NodeJS, from C#</Title>
-        <Description>Jering.Javascript.NodeJS enables you to invoke javascript in NodeJS, from C#. With this ability, you can use javascript libraries and scripts from your C# projects.</Description>
+        <Description>Jering.Javascript.NodeJS enables you to invoke javascript in NodeJS, from C#. With this ability, you can use javascript libraries and scripts from C# projects.</Description>
         <Copyright>© 2018-2021 Jering. All rights reserved.</Copyright>
         <PackageProjectUrl>https://www.jering.tech/utilities/jering.javascript.nodejs/index</PackageProjectUrl>
         <RepositoryUrl>https://github.com/JeringTech/Javascript.NodeJS</RepositoryUrl>

--- a/src/NodeJS/NodeJSServiceCollectionExtensions.cs
+++ b/src/NodeJS/NodeJSServiceCollectionExtensions.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using System;
 using System.Collections.ObjectModel;
-using System.Net.Http;
 using System.Threading;
 
 namespace Jering.Javascript.NodeJS
@@ -22,10 +21,9 @@ namespace Jering.Javascript.NodeJS
             services.
                 AddLogging().
                 AddOptions();
-            services.AddHttpClient();
 
             // Services defined in this project
-            return services.
+            services.
                 AddSingleton<IConfigureOptions<NodeJSProcessOptions>, ConfigureNodeJSProcessOptions>().
                 AddSingleton<IHttpContentFactory, InvocationContentFactory>().
                 AddSingleton<IEmbeddedResourcesService, EmbeddedResourcesService>().
@@ -35,26 +33,16 @@ namespace Jering.Javascript.NodeJS
                 AddSingleton<IEnvironmentService, EnvironmentService>().
                 AddSingleton<IFileWatcherFactory, FileWatcherFactory>().
                 AddSingleton<IMonitorService, MonitorService>().
-                AddSingleton<ITaskService, TaskService>().
-                AddSingleton(IHttpClientServiceFactory);
-        }
-
-        internal static IHttpClientService IHttpClientServiceFactory(IServiceProvider serviceProvider)
-        {
+                AddSingleton<ITaskService, TaskService>();
 #if NETCOREAPP3_1
             // If not called, framework forces HTTP/1.1 so long as origin isn't https
             AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
 #endif
+            services.
+                AddHttpClient<IHttpClientService, HttpClientService>().
+                SetHandlerLifetime(Timeout.InfiniteTimeSpan); // No DNS changes, handler lifetime can be infinite
 
-            // Create client
-            OutOfProcessNodeJSServiceOptions outOfProcessNodeJSServiceOptions = serviceProvider.GetRequiredService<IOptions<OutOfProcessNodeJSServiceOptions>>().Value;
-            IHttpClientFactory httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
-            HttpClient httpClient = httpClientFactory.CreateClient();
-
-            // Configure
-            httpClient.Timeout = outOfProcessNodeJSServiceOptions.TimeoutMS == -1 ? Timeout.InfiniteTimeSpan : TimeSpan.FromMilliseconds(outOfProcessNodeJSServiceOptions.TimeoutMS + 1000);
-
-            return new HttpClientService(httpClient);
+            return services;
         }
 
         internal static INodeJSService INodeJSServiceFactory(IServiceProvider serviceProvider)

--- a/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpClientService.cs
+++ b/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpClientService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Extensions.Options;
+using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,9 +20,16 @@ namespace Jering.Javascript.NodeJS
         /// Creates a <see cref="HttpClientService"/>.
         /// </summary>
         /// <param name="httpClient">The <see cref="HttpClient"/> to send HTTP requests with.</param>
-        public HttpClientService(HttpClient httpClient)
+        /// <param name="outOfProcessNodeJSServiceOptionsAccessor"></param>
+        public HttpClientService(HttpClient httpClient,
+            IOptions<OutOfProcessNodeJSServiceOptions> outOfProcessNodeJSServiceOptionsAccessor)
         {
             _httpClient = httpClient;
+
+            // Configure
+            OutOfProcessNodeJSServiceOptions outOfProcessNodeJSServiceOptions = outOfProcessNodeJSServiceOptionsAccessor.Value;
+            httpClient.Timeout = outOfProcessNodeJSServiceOptions.TimeoutMS == -1 ? System.Threading.Timeout.InfiniteTimeSpan :
+                TimeSpan.FromMilliseconds(outOfProcessNodeJSServiceOptions.TimeoutMS + 1000);
         }
 
         /// <inheritdoc />

--- a/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpNodeJSService.cs
+++ b/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpNodeJSService.cs
@@ -22,6 +22,7 @@ namespace Jering.Javascript.NodeJS
 
         private readonly IHttpContentFactory _httpContentFactory;
         private readonly IJsonService _jsonService;
+        private readonly ILogger<HttpNodeJSService> _logger;
         private readonly IHttpClientService _httpClientService;
 
         private bool _disposed;
@@ -41,7 +42,7 @@ namespace Jering.Javascript.NodeJS
         /// <param name="httpClientService"></param>
         /// <param name="jsonService"></param>
         /// <param name="nodeJSProcessFactory"></param>
-        /// <param name="loggerFactory"></param>
+        /// <param name="logger"></param>
         public HttpNodeJSService(IOptions<OutOfProcessNodeJSServiceOptions> outOfProcessNodeJSServiceOptionsAccessor,
             IHttpContentFactory httpContentFactory,
             IEmbeddedResourcesService embeddedResourcesService,
@@ -51,9 +52,9 @@ namespace Jering.Javascript.NodeJS
             IHttpClientService httpClientService,
             IJsonService jsonService,
             INodeJSProcessFactory nodeJSProcessFactory,
-            ILoggerFactory loggerFactory) :
+            ILogger<HttpNodeJSService> logger) :
             base(nodeJSProcessFactory,
-                loggerFactory.CreateLogger(typeof(HttpNodeJSService)),
+                logger,
                 outOfProcessNodeJSServiceOptionsAccessor,
                 embeddedResourcesService,
                 fileWatcherFactory,
@@ -64,39 +65,8 @@ namespace Jering.Javascript.NodeJS
         {
             _httpClientService = httpClientService;
             _jsonService = jsonService;
+            _logger = logger;
             _httpContentFactory = httpContentFactory;
-        }
-
-        // DO NOT DELETE - keep for backward compatibility.
-        /// <summary>
-        /// <para>Creates a <see cref="HttpNodeJSService"/>.</para> 
-        /// <para>If this constructor is used, file watching is disabled.</para>
-        /// </summary>
-        /// <param name="outOfProcessNodeJSServiceOptionsAccessor"></param>
-        /// <param name="httpContentFactory"></param>
-        /// <param name="embeddedResourcesService"></param>
-        /// <param name="httpClientService"></param>
-        /// <param name="jsonService"></param>
-        /// <param name="nodeJSProcessFactory"></param>
-        /// <param name="loggerFactory"></param>
-        public HttpNodeJSService(IOptions<OutOfProcessNodeJSServiceOptions> outOfProcessNodeJSServiceOptionsAccessor,
-            IHttpContentFactory httpContentFactory,
-            IEmbeddedResourcesService embeddedResourcesService,
-            IHttpClientService httpClientService,
-            IJsonService jsonService,
-            INodeJSProcessFactory nodeJSProcessFactory,
-            ILoggerFactory loggerFactory) :
-            this(outOfProcessNodeJSServiceOptionsAccessor,
-                httpContentFactory,
-                embeddedResourcesService,
-                null,
-                null,
-                null,
-                httpClientService,
-                jsonService,
-                nodeJSProcessFactory,
-                loggerFactory)
-        {
         }
 
         /// <inheritdoc />
@@ -201,6 +171,7 @@ namespace Jering.Javascript.NodeJS
                 else if (currentChar == ']')
                 {
                     _endpoint = new Uri(stringBuilder.ToString());
+                    _logger.LogInformation(string.Format(Strings.LogInformation_HttpEndpoint, _endpoint));
                     return;
                 }
                 else

--- a/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/IHttpClientService.cs
+++ b/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/IHttpClientService.cs
@@ -13,7 +13,7 @@ namespace Jering.Javascript.NodeJS
         /// <summary>
         /// Gets or sets the timespan to wait before the request times out.
         /// </summary>
-        TimeSpan Timeout {get; set;}
+        TimeSpan Timeout { get; set; }
 
         /// <summary>
         /// Send an HTTP request as an asynchronous operation.

--- a/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/InvocationContent.cs
+++ b/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/InvocationContent.cs
@@ -16,9 +16,9 @@ namespace Jering.Javascript.NodeJS
     public class InvocationContent : HttpContent
     {
         // Arbitrary boundary
-        internal static readonly byte[] BOUNDARY_BYTES = Encoding.UTF8.GetBytes("--Uiw6+hXl3k+5ia0cUYGhjA==");
+        internal static readonly byte[] _boundaryBytes = Encoding.UTF8.GetBytes("--Uiw6+hXl3k+5ia0cUYGhjA==");
 
-        private static readonly MediaTypeHeaderValue MULTIPART_CONTENT_TYPE = new MediaTypeHeaderValue("multipart/mixed");
+        private static readonly MediaTypeHeaderValue _multipartContentType = new MediaTypeHeaderValue("multipart/mixed");
         private readonly IJsonService _jsonService;
         private readonly InvocationRequest _invocationRequest;
 
@@ -34,7 +34,7 @@ namespace Jering.Javascript.NodeJS
 
             if (invocationRequest.ModuleSourceType == ModuleSourceType.Stream)
             {
-                Headers.ContentType = MULTIPART_CONTENT_TYPE;
+                Headers.ContentType = _multipartContentType;
             }
         }
 
@@ -50,7 +50,7 @@ namespace Jering.Javascript.NodeJS
 
             if (_invocationRequest.ModuleSourceType == ModuleSourceType.Stream)
             {
-                await stream.WriteAsync(BOUNDARY_BYTES, 0, BOUNDARY_BYTES.Length).ConfigureAwait(false);
+                await stream.WriteAsync(_boundaryBytes, 0, _boundaryBytes.Length).ConfigureAwait(false);
                 await _invocationRequest.ModuleStreamSource.CopyToAsync(stream).ConfigureAwait(false);
             }
         }

--- a/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/OutOfProcessNodeJSService.cs
+++ b/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/OutOfProcessNodeJSService.cs
@@ -353,7 +353,7 @@ namespace Jering.Javascript.NodeJS
                 return;
             }
 
-            // // Apart from the thread creating the process, all other threads will be blocked.
+            // Apart from the thread creating the process, all other threads will be blocked.
             lock (_connectingLock)
             {
                 if (_nodeJSProcess?.Connected == true)
@@ -658,7 +658,7 @@ namespace Jering.Javascript.NodeJS
 
                 waitHandle.Set();
             }
-            else if(_infoLoggingEnabled)
+            else if (_infoLoggingEnabled)
             {
                 Logger.LogInformation(message);
             }

--- a/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/OutOfProcessNodeJSService.cs
+++ b/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/OutOfProcessNodeJSService.cs
@@ -441,11 +441,11 @@ namespace Jering.Javascript.NodeJS
         // To do this, we store invoke tasks and call Task.WaitAll on them before killing processes.
         //
         // We store invoke tasks in an air-tight manner.
-        // When a file event occurs, we enter _connectionLock and ditch the current process (see FileChangedHandler). 
+        // When a file event occurs, we enter _connectionLock and ditch the current process (see MoveToNewProcess). 
         // Subsequent invocations get blocked in ConnectIfNotConnected. However, there may be in-flight invocations that have gotten past 
         // ConnectIfNotConnected. These invocations could be sent to the ditched process.
         // Therefore we allow their threads to "drain" past the task creation block (see TryTrackedInvokeAsync) before we store
-        // invoke tasks (see MoveToNewProcess). 
+        // invoke tasks (see SwapProcesses). 
         //
         // With this sytem in place, we're guaranteed to get every invoke task sent to the process we're ditching.
 
@@ -507,7 +507,7 @@ namespace Jering.Javascript.NodeJS
             }
             finally
             {
-                // Remove completed task, note that it might already have been removed in MoveToNewProcess
+                // Remove completed task, note that it might already have been removed in SwapProcesses
                 trackedInvokeTasks.TryRemove(trackedInvokeTask, out object _);
             }
         }
@@ -542,7 +542,7 @@ namespace Jering.Javascript.NodeJS
                     Logger.LogInformation(string.Format(Strings.LogInformation_FileChangedMovingtoNewNodeJSProcess, path));
                 }
 
-                MoveToNewProcess();
+                SwapProcesses();
             }
             finally
             {
@@ -553,7 +553,7 @@ namespace Jering.Javascript.NodeJS
             }
         }
 
-        internal virtual void MoveToNewProcess()
+        internal virtual void SwapProcesses()
         {
             INodeJSProcess lastNodeJSProcess = null;
             ICollection<Task> lastProcessInvokeTasks = null;

--- a/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/OutOfProcessNodeJSService.cs
+++ b/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/OutOfProcessNodeJSService.cs
@@ -514,6 +514,16 @@ namespace Jering.Javascript.NodeJS
 
         // FileSystemWatcher handles file events synchronously, storing pending events in a buffer - https://github.com/dotnet/runtime/blob/master/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs.
         // We don't need to worry about this method being called simultaneously by multiple threads.
+        internal virtual void FileChangedHandler(string path)
+        {
+            if (_infoLoggingEnabled)
+            {
+                Logger.LogInformation(string.Format(Strings.LogInformation_FileChangedMovingtoNewNodeJSProcess, path));
+            }
+
+            MoveToNewProcess(true);
+        }
+
         internal virtual void MoveToNewProcess(bool reswapIfJustConnected)
         {
             bool acquiredConnectingLock = false;

--- a/src/NodeJS/StaticNodeJSService.cs
+++ b/src/NodeJS/StaticNodeJSService.cs
@@ -14,13 +14,13 @@ namespace Jering.Javascript.NodeJS
         private static volatile ServiceProvider _serviceProvider;
         private static volatile IServiceCollection _services;
         private static volatile INodeJSService _nodeJSService;
-        private static readonly object CREATE_LOCK = new object();
+        private static readonly object _createLock = new object();
 
         private static INodeJSService GetOrCreateNodeJSService()
         {
             if (_nodeJSService == null || _services != null)
             {
-                lock (CREATE_LOCK)
+                lock (_createLock)
                 {
                     if (_nodeJSService == null || _services != null)
                     {

--- a/src/NodeJS/Strings.Designer.cs
+++ b/src/NodeJS/Strings.Designer.cs
@@ -257,13 +257,22 @@ namespace Jering.Javascript.NodeJS {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An invocation attempt failed. Retries remaining: {0}.
+        ///   Looks up a localized string similar to An invocation attempt failed. Retries using existing process remaining: {0}.
         ///Exception:
         ///  {1}.
         /// </summary>
         internal static string LogWarning_InvocationAttemptFailed {
             get {
                 return ResourceManager.GetString("LogWarning_InvocationAttemptFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Retries in existing process exhausted. Process retries remaining: {0}..
+        /// </summary>
+        internal static string LogWarning_RetriesInExistingProcessExhausted {
+            get {
+                return ResourceManager.GetString("LogWarning_RetriesInExistingProcessExhausted", resourceCulture);
             }
         }
     }

--- a/src/NodeJS/Strings.Designer.cs
+++ b/src/NodeJS/Strings.Designer.cs
@@ -228,6 +228,15 @@ namespace Jering.Javascript.NodeJS {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Connected to NodeJS through HTTP. Endpoint: {0}..
+        /// </summary>
+        internal static string LogInformation_HttpEndpoint {
+            get {
+                return ResourceManager.GetString("LogInformation_HttpEndpoint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Killing NodeJS process: {0}..
         /// </summary>
         internal static string LogInformation_KillingNodeJSProcess {

--- a/src/NodeJS/Strings.resx
+++ b/src/NodeJS/Strings.resx
@@ -188,4 +188,7 @@ Exception:
   <data name="ArgumentException_Shared_ValueCannotBeNullWhitespaceOrAnEmptyString" xml:space="preserve">
     <value>Value cannot be null, whitespace or an empty string.</value>
   </data>
+  <data name="LogInformation_HttpEndpoint" xml:space="preserve">
+    <value>Connected to NodeJS through HTTP. Endpoint: {0}.</value>
+  </data>
 </root>

--- a/src/NodeJS/Strings.resx
+++ b/src/NodeJS/Strings.resx
@@ -161,7 +161,7 @@
     <value>Before wait, thread ID: {0}.</value>
   </data>
   <data name="LogWarning_InvocationAttemptFailed" xml:space="preserve">
-    <value>An invocation attempt failed. Retries remaining: {0}.
+    <value>An invocation attempt failed. Retries using existing process remaining: {0}.
 Exception:
   {1}</value>
   </data>
@@ -190,5 +190,8 @@ Exception:
   </data>
   <data name="LogInformation_HttpEndpoint" xml:space="preserve">
     <value>Connected to NodeJS through HTTP. Endpoint: {0}.</value>
+  </data>
+  <data name="LogWarning_RetriesInExistingProcessExhausted" xml:space="preserve">
+    <value>Retries in existing process exhausted. Process retries remaining: {0}.</value>
   </data>
 </root>

--- a/src/NodeJS/Utils/JsonService.cs
+++ b/src/NodeJS/Utils/JsonService.cs
@@ -11,7 +11,7 @@ namespace Jering.Javascript.NodeJS
     /// </summary>
     public class JsonService : IJsonService
     {
-        private static readonly JsonSerializerOptions JSON_SERIALIZER_OPTIONS = new JsonSerializerOptions
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
         {
             Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
 
@@ -24,13 +24,13 @@ namespace Jering.Javascript.NodeJS
         /// <inheritdoc />
         public ValueTask<T> DeserializeAsync<T>(Stream stream, CancellationToken cancellationToken = default)
         {
-            return JsonSerializer.DeserializeAsync<T>(stream, JSON_SERIALIZER_OPTIONS, cancellationToken);
+            return JsonSerializer.DeserializeAsync<T>(stream, _jsonSerializerOptions, cancellationToken);
         }
 
         /// <inheritdoc />
         public Task SerializeAsync<T>(Stream stream, T value, CancellationToken cancellationToken = default)
         {
-            return JsonSerializer.SerializeAsync(stream, value, JSON_SERIALIZER_OPTIONS, cancellationToken);
+            return JsonSerializer.SerializeAsync(stream, value, _jsonSerializerOptions, cancellationToken);
         }
     }
 }

--- a/test/NodeJS/HttpClientServiceUnitTests.cs
+++ b/test/NodeJS/HttpClientServiceUnitTests.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.Extensions.Options;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using Xunit;
+
+namespace Jering.Javascript.NodeJS.Tests
+{
+    public class HttpClientServiceUnitTests
+    {
+        private readonly MockRepository _mockRepository = new MockRepository(MockBehavior.Default);
+
+        [Theory]
+        [MemberData(nameof(Constructor_SetsTimeout_Data))]
+        public void Constructor_SetsTimeout(int dummyTimeoutMS, TimeSpan expectedTimeoutMS)
+        {
+            // Arrange
+            var dummyOptions = new OutOfProcessNodeJSServiceOptions() { TimeoutMS = dummyTimeoutMS };
+            Mock<IOptions<OutOfProcessNodeJSServiceOptions>> mockOptionsAccessor = _mockRepository.Create<IOptions<OutOfProcessNodeJSServiceOptions>>();
+            mockOptionsAccessor.Setup(o => o.Value).Returns(dummyOptions);
+            using var dummyHttpClient = new HttpClient();
+
+            // Act
+            var result = new HttpClientService(dummyHttpClient, mockOptionsAccessor.Object);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(expectedTimeoutMS, result.Timeout);
+        }
+
+        public static IEnumerable<object[]> Constructor_SetsTimeout_Data()
+        {
+            return new object[][]
+            {
+                // -1 == infinite
+                new object[]{ -1, Timeout.InfiniteTimeSpan},
+                // All other values == value + 1000
+                new object[]{ 0, TimeSpan.FromMilliseconds(1000)},
+                new object[]{ 1000, TimeSpan.FromMilliseconds(2000)}
+            };
+        }
+    }
+}

--- a/test/NodeJS/HttpNodeJSPoolServiceIntegrationTests.cs
+++ b/test/NodeJS/HttpNodeJSPoolServiceIntegrationTests.cs
@@ -29,7 +29,7 @@ namespace Jering.Javascript.NodeJS.Tests
         private const int TIMEOUT_MS = 60000;
 
         // File watching
-        private static readonly string TEMP_WATCH_DIRECTORY = Path.Combine(Path.GetTempPath(), nameof(HttpNodeJSPoolServiceIntegrationTests) + "/"); // Dummy directory to watch for file changes
+        private static readonly string _tempWatchDirectory = Path.Combine(Path.GetTempPath(), nameof(HttpNodeJSPoolServiceIntegrationTests) + "/"); // Dummy directory to watch for file changes
         private Uri _tempWatchDirectoryUri;
 
         private readonly ITestOutputHelper _testOutputHelper;
@@ -111,7 +111,7 @@ namespace Jering.Javascript.NodeJS.Tests
             dummyServices.Configure<OutOfProcessNodeJSServiceOptions>(options =>
             {
                 options.EnableFileWatching = true;
-                options.WatchPath = TEMP_WATCH_DIRECTORY;
+                options.WatchPath = _tempWatchDirectory;
                 // Graceful shutdown is true by default
             });
             HttpNodeJSPoolService testSubject = CreateHttpNodeJSPoolService(dummyNumProcesses, dummyServices);
@@ -182,7 +182,7 @@ namespace Jering.Javascript.NodeJS.Tests
             dummyServices.Configure<OutOfProcessNodeJSServiceOptions>(options =>
             {
                 options.EnableFileWatching = true;
-                options.WatchPath = TEMP_WATCH_DIRECTORY;
+                options.WatchPath = _tempWatchDirectory;
                 options.WatchGracefulShutdown = false;
             });
             HttpNodeJSPoolService testSubject = CreateHttpNodeJSPoolService(dummyNumProcesses, dummyServices, resultStringBuilder);
@@ -292,15 +292,15 @@ namespace Jering.Javascript.NodeJS.Tests
         private void RecreateWatchDirectory()
         {
             TryDeleteWatchDirectory();
-            Directory.CreateDirectory(TEMP_WATCH_DIRECTORY);
-            _tempWatchDirectoryUri = new Uri(TEMP_WATCH_DIRECTORY);
+            Directory.CreateDirectory(_tempWatchDirectory);
+            _tempWatchDirectoryUri = new Uri(_tempWatchDirectory);
         }
 
         private void TryDeleteWatchDirectory()
         {
             try
             {
-                Directory.Delete(TEMP_WATCH_DIRECTORY, true);
+                Directory.Delete(_tempWatchDirectory, true);
             }
             catch
             {

--- a/test/NodeJS/HttpNodeJSPoolServiceIntegrationTests.cs
+++ b/test/NodeJS/HttpNodeJSPoolServiceIntegrationTests.cs
@@ -86,7 +86,7 @@ namespace Jering.Javascript.NodeJS.Tests
 
         // When graceful shutdown is true, we kill initial processes only after their invocations complete.
         [Fact(Timeout = TIMEOUT_MS)]
-        public async void FileWatching_RespectsWatchGracefulShutdownOptionWhenItsTrue()
+        public async void FileWatching_RespectsGracefulShutdownOptionWhenItsTrue()
         {
             // Arrange
             const int dummyNumProcesses = 5;
@@ -165,7 +165,7 @@ namespace Jering.Javascript.NodeJS.Tests
 
         // When graceful shutdown is false, we kill the initial process immediately. Invocation retry in the new process.
         [Fact(Timeout = TIMEOUT_MS)]
-        public async void FileWatching_RespectsWatchGracefulShutdownOptionWhenItsFalse()
+        public async void FileWatching_RespectsGracefulShutdownOptionWhenItsFalse()
         {
             // Arrange
             const int dummyNumProcesses = 5;
@@ -183,7 +183,7 @@ namespace Jering.Javascript.NodeJS.Tests
             {
                 options.EnableFileWatching = true;
                 options.WatchPath = _tempWatchDirectory;
-                options.WatchGracefulShutdown = false;
+                options.GracefulProcessShutdown = false;
             });
             HttpNodeJSPoolService testSubject = CreateHttpNodeJSPoolService(dummyNumProcesses, dummyServices, resultStringBuilder);
 

--- a/test/NodeJS/HttpNodeJSPoolServiceUnitTests.cs
+++ b/test/NodeJS/HttpNodeJSPoolServiceUnitTests.cs
@@ -339,51 +339,59 @@ namespace Jering.Javascript.NodeJS.Tests
         private Mock<HttpNodeJSService> CreateMockHttpNodeJSService(IOptions<OutOfProcessNodeJSServiceOptions> outOfProcessNodeHostOptionsAccessor = null,
             IHttpContentFactory httpContentFactory = null,
             IEmbeddedResourcesService embeddedResourcesService = null,
+            IFileWatcherFactory fileWatcherFactory = null,
+            IMonitorService monitorService = null,
+            ITaskService taskService = null,
             IHttpClientService httpClientService = null,
             IJsonService jsonService = null,
             INodeJSProcessFactory nodeProcessFactory = null,
-            ILoggerFactory loggerFactory = null)
+            ILogger<HttpNodeJSService> logger = null)
         {
-            if (loggerFactory == null)
+            if (logger == null)
             {
-                Mock<ILogger> mockLogger = _mockRepository.Create<ILogger>();
-                Mock<ILoggerFactory> mockLoggerFactory = _mockRepository.Create<ILoggerFactory>();
-                mockLoggerFactory.Setup(l => l.CreateLogger(typeof(HttpNodeJSService).FullName)).Returns(mockLogger.Object);
-                loggerFactory = mockLoggerFactory.Object;
+                Mock<ILogger<HttpNodeJSService>> mockLogger = _mockRepository.Create<ILogger<HttpNodeJSService>>();
+                logger = mockLogger.Object;
             }
 
             return _mockRepository.Create<HttpNodeJSService>(outOfProcessNodeHostOptionsAccessor,
                 httpContentFactory,
                 embeddedResourcesService,
+                fileWatcherFactory,
+                monitorService,
+                taskService,
                 httpClientService,
                 jsonService,
                 nodeProcessFactory,
-                loggerFactory);
+                logger);
         }
 
         private HttpNodeJSService CreateHttpNodeJSService(IOptions<OutOfProcessNodeJSServiceOptions> outOfProcessNodeHostOptionsAccessor = null,
             IHttpContentFactory httpContentFactory = null,
             IEmbeddedResourcesService embeddedResourcesService = null,
+            IFileWatcherFactory fileWatcherFactory = null,
+            IMonitorService monitorService = null,
+            ITaskService taskService = null,
             IHttpClientService httpClientService = null,
             IJsonService jsonService = null,
             INodeJSProcessFactory nodeProcessFactory = null,
-            ILoggerFactory loggerFactory = null)
+            ILogger<HttpNodeJSService> logger = null)
         {
-            if (loggerFactory == null)
+            if (logger == null)
             {
-                Mock<ILogger> mockLogger = _mockRepository.Create<ILogger>();
-                Mock<ILoggerFactory> mockLoggerFactory = _mockRepository.Create<ILoggerFactory>();
-                mockLoggerFactory.Setup(l => l.CreateLogger(typeof(HttpNodeJSService).FullName)).Returns(mockLogger.Object);
-                loggerFactory = mockLoggerFactory.Object;
+                Mock<ILogger<HttpNodeJSService>> mockLogger = _mockRepository.Create<ILogger<HttpNodeJSService>>();
+                logger = mockLogger.Object;
             }
 
             return new HttpNodeJSService(outOfProcessNodeHostOptionsAccessor,
                 httpContentFactory,
                 embeddedResourcesService,
+                fileWatcherFactory,
+                monitorService,
+                taskService,
                 httpClientService,
                 jsonService,
                 nodeProcessFactory,
-                loggerFactory);
+                logger);
         }
     }
 }

--- a/test/NodeJS/HttpNodeJSServiceIntegrationTests.cs
+++ b/test/NodeJS/HttpNodeJSServiceIntegrationTests.cs
@@ -28,12 +28,12 @@ namespace Jering.Javascript.NodeJS.Tests
         private const string DUMMY_RETURNS_ARG_MODULE_FILE = "dummyReturnsArgModule.js";
         private const string DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE_FILE = "dummyExportsMultipleFunctionsModule.js";
         private const string DUMMY_CACHE_IDENTIFIER = "dummyCacheIdentifier";
-        private static readonly string PROJECT_PATH = Path.Combine(Directory.GetCurrentDirectory(), "../../../Javascript"); // Current directory is <test project path>/bin/debug/<framework>
-        private static readonly string DUMMY_RETURNS_ARG_MODULE = File.ReadAllText(Path.Combine(PROJECT_PATH, DUMMY_RETURNS_ARG_MODULE_FILE));
-        private static readonly string DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE = File.ReadAllText(Path.Combine(PROJECT_PATH, DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE_FILE));
+        private static readonly string _projectPath = Path.Combine(Directory.GetCurrentDirectory(), "../../../Javascript"); // Current directory is <test project path>/bin/debug/<framework>
+        private static readonly string _dummyReturnsArgModule = File.ReadAllText(Path.Combine(_projectPath, DUMMY_RETURNS_ARG_MODULE_FILE));
+        private static readonly string _dummyExportsMultipleFunctionsModule = File.ReadAllText(Path.Combine(_projectPath, DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE_FILE));
 
         // File watching
-        private static readonly string TEMP_WATCH_DIRECTORY = Path.Combine(Path.GetTempPath(), nameof(HttpNodeJSServiceIntegrationTests) + "/"); // Dummy directory to watch for file changes
+        private static readonly string _tempWatchDirectory = Path.Combine(Path.GetTempPath(), nameof(HttpNodeJSServiceIntegrationTests) + "/"); // Dummy directory to watch for file changes
         private Uri _tempWatchDirectoryUri;
 
         private readonly ITestOutputHelper _testOutputHelper;
@@ -48,7 +48,7 @@ namespace Jering.Javascript.NodeJS.Tests
         public async void InvokeFromFileAsync_WithTypeParameter_InvokesFromFile()
         {
             const string dummyArg = "success";
-            HttpNodeJSService testSubject = CreateHttpNodeJSService(projectPath: PROJECT_PATH);
+            HttpNodeJSService testSubject = CreateHttpNodeJSService(projectPath: _projectPath);
 
             // Act
             DummyResult result = await testSubject.
@@ -63,7 +63,7 @@ namespace Jering.Javascript.NodeJS.Tests
         {
             // Arrange
             const string dummyArg = "success";
-            HttpNodeJSService testSubject = CreateHttpNodeJSService(projectPath: PROJECT_PATH);
+            HttpNodeJSService testSubject = CreateHttpNodeJSService(projectPath: _projectPath);
 
             // Act
             var results = new ConcurrentQueue<DummyResult>();
@@ -93,7 +93,7 @@ namespace Jering.Javascript.NodeJS.Tests
         public async void InvokeFromFileAsync_WithoutTypeParameter_InvokesFromFile()
         {
             const string dummyArg = "success";
-            HttpNodeJSService testSubject = CreateHttpNodeJSService(projectPath: PROJECT_PATH);
+            HttpNodeJSService testSubject = CreateHttpNodeJSService(projectPath: _projectPath);
 
             // Act
             await testSubject.InvokeFromFileAsync(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE_FILE, "setString", new[] { dummyArg }).ConfigureAwait(false);
@@ -108,7 +108,7 @@ namespace Jering.Javascript.NodeJS.Tests
         public async void InvokeFromFileAsync_WithoutTypeParameter_IsThreadSafe()
         {
             // Arrange
-            HttpNodeJSService testSubject = CreateHttpNodeJSService(projectPath: PROJECT_PATH);
+            HttpNodeJSService testSubject = CreateHttpNodeJSService(projectPath: _projectPath);
 
             // Act
             const int numThreads = 5;
@@ -139,7 +139,7 @@ namespace Jering.Javascript.NodeJS.Tests
 
             // Act
             DummyResult result = await testSubject.
-                InvokeFromStringAsync<DummyResult>(DUMMY_RETURNS_ARG_MODULE, args: new[] { dummyArg }).ConfigureAwait(false);
+                InvokeFromStringAsync<DummyResult>(_dummyReturnsArgModule, args: new[] { dummyArg }).ConfigureAwait(false);
 
             // Assert
             Assert.Equal(dummyArg, result.Result);
@@ -159,7 +159,7 @@ namespace Jering.Javascript.NodeJS.Tests
             for (int i = 0; i < numThreads; i++)
             {
                 var thread = new Thread(() => results.Enqueue(testSubject.
-                    InvokeFromStringAsync<DummyResult>(DUMMY_RETURNS_ARG_MODULE, args: new[] { dummyArg }).GetAwaiter().GetResult()));
+                    InvokeFromStringAsync<DummyResult>(_dummyReturnsArgModule, args: new[] { dummyArg }).GetAwaiter().GetResult()));
                 threads.Add(thread);
                 thread.Start();
             }
@@ -180,14 +180,14 @@ namespace Jering.Javascript.NodeJS.Tests
         public async void InvokeFromStringAsync_WithoutTypeParameter_WithRawStringModule_InvokesFromString()
         {
             const string dummyArg = "success";
-            HttpNodeJSService testSubject = CreateHttpNodeJSService(projectPath: PROJECT_PATH);
+            HttpNodeJSService testSubject = CreateHttpNodeJSService(projectPath: _projectPath);
 
             // Act
-            await testSubject.InvokeFromStringAsync(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE, DUMMY_CACHE_IDENTIFIER, "setString", new[] { dummyArg }).ConfigureAwait(false);
+            await testSubject.InvokeFromStringAsync(_dummyExportsMultipleFunctionsModule, DUMMY_CACHE_IDENTIFIER, "setString", new[] { dummyArg }).ConfigureAwait(false);
 
             // Assert
             DummyResult result = await testSubject.
-                InvokeFromStringAsync<DummyResult>(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE, DUMMY_CACHE_IDENTIFIER, "getString").ConfigureAwait(false);
+                InvokeFromStringAsync<DummyResult>(_dummyExportsMultipleFunctionsModule, DUMMY_CACHE_IDENTIFIER, "getString").ConfigureAwait(false);
             Assert.Equal(dummyArg, result.Result);
         }
 
@@ -195,7 +195,7 @@ namespace Jering.Javascript.NodeJS.Tests
         public async void InvokeFromStringAsync_WithoutTypeParameter_WithRawStringModule_IsThreadSafe()
         {
             // Arrange
-            HttpNodeJSService testSubject = CreateHttpNodeJSService(projectPath: PROJECT_PATH);
+            HttpNodeJSService testSubject = CreateHttpNodeJSService(projectPath: _projectPath);
 
             // Act
             const int numThreads = 5;
@@ -203,7 +203,7 @@ namespace Jering.Javascript.NodeJS.Tests
             for (int i = 0; i < numThreads; i++)
             {
                 var thread = new Thread(() => testSubject.
-                    InvokeFromStringAsync(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE, DUMMY_CACHE_IDENTIFIER, "incrementNumber").GetAwaiter().GetResult());
+                    InvokeFromStringAsync(_dummyExportsMultipleFunctionsModule, DUMMY_CACHE_IDENTIFIER, "incrementNumber").GetAwaiter().GetResult());
                 threads.Add(thread);
                 thread.Start();
             }
@@ -213,7 +213,7 @@ namespace Jering.Javascript.NodeJS.Tests
             }
 
             // Assert
-            int result = await testSubject.InvokeFromStringAsync<int>(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE, DUMMY_CACHE_IDENTIFIER, "getNumber").ConfigureAwait(false);
+            int result = await testSubject.InvokeFromStringAsync<int>(_dummyExportsMultipleFunctionsModule, DUMMY_CACHE_IDENTIFIER, "getNumber").ConfigureAwait(false);
             Assert.Equal(numThreads, result);
         }
 
@@ -223,7 +223,7 @@ namespace Jering.Javascript.NodeJS.Tests
             // Arrange
             const string dummyArg = "success";
             HttpNodeJSService testSubject = CreateHttpNodeJSService();
-            await testSubject.InvokeFromStringAsync(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE, DUMMY_CACHE_IDENTIFIER, "setString", new[] { dummyArg }).ConfigureAwait(false);
+            await testSubject.InvokeFromStringAsync(_dummyExportsMultipleFunctionsModule, DUMMY_CACHE_IDENTIFIER, "setString", new[] { dummyArg }).ConfigureAwait(false);
 
             // Act
             DummyResult result = await testSubject.
@@ -243,7 +243,7 @@ namespace Jering.Javascript.NodeJS.Tests
             // Act
             // Module hasn't been cached, so if this returns the expected value, string was sent over
             DummyResult result1 = await testSubject.
-                InvokeFromStringAsync<DummyResult>(() => DUMMY_RETURNS_ARG_MODULE, DUMMY_CACHE_IDENTIFIER, args: new[] { dummyArg }).ConfigureAwait(false);
+                InvokeFromStringAsync<DummyResult>(() => _dummyReturnsArgModule, DUMMY_CACHE_IDENTIFIER, args: new[] { dummyArg }).ConfigureAwait(false);
 
             // Assert
             // Ensure module was cached
@@ -266,7 +266,7 @@ namespace Jering.Javascript.NodeJS.Tests
             for (int i = 0; i < numThreads; i++)
             {
                 var thread = new Thread(() => results.Enqueue(testSubject.
-                    InvokeFromStringAsync<int>(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE, DUMMY_CACHE_IDENTIFIER, "incrementAndGetNumber").GetAwaiter().GetResult()));
+                    InvokeFromStringAsync<int>(_dummyExportsMultipleFunctionsModule, DUMMY_CACHE_IDENTIFIER, "incrementAndGetNumber").GetAwaiter().GetResult()));
                 threads.Add(thread);
                 thread.Start();
             }
@@ -291,14 +291,14 @@ namespace Jering.Javascript.NodeJS.Tests
         {
             // Arrange
             HttpNodeJSService testSubject = CreateHttpNodeJSService();
-            await testSubject.InvokeFromStringAsync(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE, DUMMY_CACHE_IDENTIFIER, "incrementNumber").ConfigureAwait(false);
+            await testSubject.InvokeFromStringAsync(_dummyExportsMultipleFunctionsModule, DUMMY_CACHE_IDENTIFIER, "incrementNumber").ConfigureAwait(false);
 
             // Act
             await testSubject.
                 InvokeFromStringAsync(() => null, DUMMY_CACHE_IDENTIFIER, "incrementNumber").ConfigureAwait(false);
 
             // Assert
-            int result = await testSubject.InvokeFromStringAsync<int>(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE, DUMMY_CACHE_IDENTIFIER, "getNumber").ConfigureAwait(false);
+            int result = await testSubject.InvokeFromStringAsync<int>(_dummyExportsMultipleFunctionsModule, DUMMY_CACHE_IDENTIFIER, "getNumber").ConfigureAwait(false);
             Assert.Equal(2, result);
         }
 
@@ -310,7 +310,7 @@ namespace Jering.Javascript.NodeJS.Tests
 
             // Act
             await testSubject.
-                InvokeFromStringAsync(() => DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE, DUMMY_CACHE_IDENTIFIER, "incrementNumber").ConfigureAwait(false);
+                InvokeFromStringAsync(() => _dummyExportsMultipleFunctionsModule, DUMMY_CACHE_IDENTIFIER, "incrementNumber").ConfigureAwait(false);
 
             // Assert
             // Ensure module was cached
@@ -331,7 +331,7 @@ namespace Jering.Javascript.NodeJS.Tests
             for (int i = 0; i < numThreads; i++)
             {
                 var thread = new Thread(() => testSubject.
-                    InvokeFromStringAsync(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE, DUMMY_CACHE_IDENTIFIER, "incrementNumber").GetAwaiter().GetResult());
+                    InvokeFromStringAsync(_dummyExportsMultipleFunctionsModule, DUMMY_CACHE_IDENTIFIER, "incrementNumber").GetAwaiter().GetResult());
                 threads.Add(thread);
                 thread.Start();
             }
@@ -352,7 +352,7 @@ namespace Jering.Javascript.NodeJS.Tests
             // Arrange
             const string dummyArg = "success";
             HttpNodeJSService testSubject = CreateHttpNodeJSService();
-            MemoryStream memoryStream = CreateMemoryStream(DUMMY_RETURNS_ARG_MODULE);
+            MemoryStream memoryStream = CreateMemoryStream(_dummyReturnsArgModule);
 
             // Act
             DummyResult result = await testSubject.InvokeFromStreamAsync<DummyResult>(memoryStream, args: new[] { dummyArg }).ConfigureAwait(false);
@@ -376,7 +376,7 @@ namespace Jering.Javascript.NodeJS.Tests
             {
                 var thread = new Thread(() =>
                 {
-                    MemoryStream memoryStream = CreateMemoryStream(DUMMY_RETURNS_ARG_MODULE);
+                    MemoryStream memoryStream = CreateMemoryStream(_dummyReturnsArgModule);
                     results.Enqueue(testSubject.InvokeFromStreamAsync<DummyResult>(memoryStream, args: new[] { dummyArg }).GetAwaiter().GetResult());
                 });
                 threads.Add(thread);
@@ -400,8 +400,8 @@ namespace Jering.Javascript.NodeJS.Tests
         {
             // Arrange
             const string dummyArg = "success";
-            HttpNodeJSService testSubject = CreateHttpNodeJSService(projectPath: PROJECT_PATH);
-            MemoryStream memoryStream = CreateMemoryStream(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE);
+            HttpNodeJSService testSubject = CreateHttpNodeJSService(projectPath: _projectPath);
+            MemoryStream memoryStream = CreateMemoryStream(_dummyExportsMultipleFunctionsModule);
 
             // Act
             await testSubject.InvokeFromStreamAsync(memoryStream, DUMMY_CACHE_IDENTIFIER, "setString", new[] { dummyArg }).ConfigureAwait(false);
@@ -416,7 +416,7 @@ namespace Jering.Javascript.NodeJS.Tests
         public async void InvokeFromStreamAsync_WithoutTypeParameter_WithRawStreamModule_IsThreadSafe()
         {
             // Arrange
-            HttpNodeJSService testSubject = CreateHttpNodeJSService(projectPath: PROJECT_PATH);
+            HttpNodeJSService testSubject = CreateHttpNodeJSService(projectPath: _projectPath);
 
             // Act
             const int numThreads = 5;
@@ -425,7 +425,7 @@ namespace Jering.Javascript.NodeJS.Tests
             {
                 var thread = new Thread(() =>
                 {
-                    MemoryStream memoryStream = CreateMemoryStream(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE);
+                    MemoryStream memoryStream = CreateMemoryStream(_dummyExportsMultipleFunctionsModule);
                     testSubject.InvokeFromStreamAsync(memoryStream, DUMMY_CACHE_IDENTIFIER, "incrementNumber").GetAwaiter().GetResult();
                 });
                 threads.Add(thread);
@@ -438,7 +438,7 @@ namespace Jering.Javascript.NodeJS.Tests
 
             // Assert
             int result = await testSubject.
-                InvokeFromStringAsync<int>(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE, DUMMY_CACHE_IDENTIFIER, "getNumber").ConfigureAwait(false);
+                InvokeFromStringAsync<int>(_dummyExportsMultipleFunctionsModule, DUMMY_CACHE_IDENTIFIER, "getNumber").ConfigureAwait(false);
             Assert.Equal(numThreads, result);
         }
 
@@ -448,7 +448,7 @@ namespace Jering.Javascript.NodeJS.Tests
             // Arrange
             const string dummyArg = "success";
             HttpNodeJSService testSubject = CreateHttpNodeJSService();
-            MemoryStream memoryStream = CreateMemoryStream(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE);
+            MemoryStream memoryStream = CreateMemoryStream(_dummyExportsMultipleFunctionsModule);
             await testSubject.InvokeFromStreamAsync(memoryStream, DUMMY_CACHE_IDENTIFIER, "setString", new[] { dummyArg }).ConfigureAwait(false);
 
             // Act
@@ -465,7 +465,7 @@ namespace Jering.Javascript.NodeJS.Tests
             // Arrange
             const string dummyArg = "success";
             HttpNodeJSService testSubject = CreateHttpNodeJSService();
-            MemoryStream memoryStream = CreateMemoryStream(DUMMY_RETURNS_ARG_MODULE);
+            MemoryStream memoryStream = CreateMemoryStream(_dummyReturnsArgModule);
 
             // Act
             // Module hasn't been cached, so if this returns the expected value, stream was sent over
@@ -495,7 +495,7 @@ namespace Jering.Javascript.NodeJS.Tests
             {
                 var thread = new Thread(() =>
                 {
-                    MemoryStream memoryStream = CreateMemoryStream(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE);
+                    MemoryStream memoryStream = CreateMemoryStream(_dummyExportsMultipleFunctionsModule);
                     results.Enqueue(testSubject.InvokeFromStreamAsync<int>(() => memoryStream, DUMMY_CACHE_IDENTIFIER, "incrementAndGetNumber").GetAwaiter().GetResult());
                 });
                 threads.Add(thread);
@@ -522,7 +522,7 @@ namespace Jering.Javascript.NodeJS.Tests
         {
             // Arrange
             HttpNodeJSService testSubject = CreateHttpNodeJSService();
-            MemoryStream memoryStream = CreateMemoryStream(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE);
+            MemoryStream memoryStream = CreateMemoryStream(_dummyExportsMultipleFunctionsModule);
             await testSubject.InvokeFromStreamAsync(memoryStream, DUMMY_CACHE_IDENTIFIER, "incrementNumber").ConfigureAwait(false);
 
             // Act
@@ -539,7 +539,7 @@ namespace Jering.Javascript.NodeJS.Tests
         {
             // Arrange
             HttpNodeJSService testSubject = CreateHttpNodeJSService();
-            MemoryStream memoryStream = CreateMemoryStream(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE);
+            MemoryStream memoryStream = CreateMemoryStream(_dummyExportsMultipleFunctionsModule);
 
             // Act
             await testSubject.
@@ -565,7 +565,7 @@ namespace Jering.Javascript.NodeJS.Tests
             {
                 var thread = new Thread(() =>
                 {
-                    MemoryStream memoryStream = CreateMemoryStream(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE);
+                    MemoryStream memoryStream = CreateMemoryStream(_dummyExportsMultipleFunctionsModule);
                     testSubject.InvokeFromStreamAsync(memoryStream, DUMMY_CACHE_IDENTIFIER, "incrementNumber").GetAwaiter().GetResult();
                 });
                 threads.Add(thread);
@@ -588,7 +588,7 @@ namespace Jering.Javascript.NodeJS.Tests
             // Arrange
             const string dummyArg = "success";
             HttpNodeJSService testSubject = CreateHttpNodeJSService();
-            await testSubject.InvokeFromStringAsync<DummyResult>(DUMMY_RETURNS_ARG_MODULE, DUMMY_CACHE_IDENTIFIER, args: new[] { dummyArg }).ConfigureAwait(false);
+            await testSubject.InvokeFromStringAsync<DummyResult>(_dummyReturnsArgModule, DUMMY_CACHE_IDENTIFIER, args: new[] { dummyArg }).ConfigureAwait(false);
 
             // Act
             (bool success, DummyResult value) = await testSubject.TryInvokeFromCacheAsync<DummyResult>(DUMMY_CACHE_IDENTIFIER, args: new[] { dummyArg }).ConfigureAwait(false);
@@ -618,7 +618,7 @@ namespace Jering.Javascript.NodeJS.Tests
             // Arrange
             const string dummyArg = "success";
             HttpNodeJSService testSubject = CreateHttpNodeJSService();
-            await testSubject.InvokeFromStringAsync<DummyResult>(DUMMY_RETURNS_ARG_MODULE, DUMMY_CACHE_IDENTIFIER, args: new[] { dummyArg }).ConfigureAwait(false);
+            await testSubject.InvokeFromStringAsync<DummyResult>(_dummyReturnsArgModule, DUMMY_CACHE_IDENTIFIER, args: new[] { dummyArg }).ConfigureAwait(false);
 
             // Act
             var results = new ConcurrentQueue<(bool, DummyResult)>();
@@ -650,14 +650,14 @@ namespace Jering.Javascript.NodeJS.Tests
         {
             // Arrange
             HttpNodeJSService testSubject = CreateHttpNodeJSService();
-            await testSubject.InvokeFromStringAsync(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE, DUMMY_CACHE_IDENTIFIER, "incrementNumber").ConfigureAwait(false);
+            await testSubject.InvokeFromStringAsync(_dummyExportsMultipleFunctionsModule, DUMMY_CACHE_IDENTIFIER, "incrementNumber").ConfigureAwait(false);
 
             // Act
             bool success = await testSubject.TryInvokeFromCacheAsync(DUMMY_CACHE_IDENTIFIER, "incrementNumber").ConfigureAwait(false);
 
             // Assert
             Assert.True(success);
-            int result = await testSubject.InvokeFromStringAsync<int>(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE, DUMMY_CACHE_IDENTIFIER, "getNumber").ConfigureAwait(false);
+            int result = await testSubject.InvokeFromStringAsync<int>(_dummyExportsMultipleFunctionsModule, DUMMY_CACHE_IDENTIFIER, "getNumber").ConfigureAwait(false);
             Assert.Equal(2, result);
         }
 
@@ -679,7 +679,7 @@ namespace Jering.Javascript.NodeJS.Tests
         {
             // Arrange
             HttpNodeJSService testSubject = CreateHttpNodeJSService();
-            await testSubject.InvokeFromStringAsync(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE, DUMMY_CACHE_IDENTIFIER, "incrementNumber").ConfigureAwait(false);
+            await testSubject.InvokeFromStringAsync(_dummyExportsMultipleFunctionsModule, DUMMY_CACHE_IDENTIFIER, "incrementNumber").ConfigureAwait(false);
 
             // Act
             const int numThreads = 5;
@@ -696,7 +696,7 @@ namespace Jering.Javascript.NodeJS.Tests
             }
 
             // Assert
-            int result = await testSubject.InvokeFromStringAsync<int>(DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE, DUMMY_CACHE_IDENTIFIER, "getNumber").ConfigureAwait(false);
+            int result = await testSubject.InvokeFromStringAsync<int>(_dummyExportsMultipleFunctionsModule, DUMMY_CACHE_IDENTIFIER, "getNumber").ConfigureAwait(false);
             Assert.Equal(numThreads + 1, result);
         }
 
@@ -709,7 +709,7 @@ namespace Jering.Javascript.NodeJS.Tests
     // Example comment
     return arg + ""dummyString"";
 }";
-            HttpNodeJSService testSubject = CreateHttpNodeJSService(projectPath: PROJECT_PATH);
+            HttpNodeJSService testSubject = CreateHttpNodeJSService(projectPath: _projectPath);
 
             // Act
             string result = await testSubject.InvokeFromStringAsync<string>(@"const prismjs = require('prismjs');
@@ -734,7 +734,7 @@ module.exports = (callback, code) => {
         public async void InMemoryInvokeMethods_LoadRequiredModulesFromFilesInProjectDirectory()
         {
             // Arrange
-            HttpNodeJSService testSubject = CreateHttpNodeJSService(projectPath: PROJECT_PATH); // Current directory is <test project path>/bin/debug/<framework>
+            HttpNodeJSService testSubject = CreateHttpNodeJSService(projectPath: _projectPath); // Current directory is <test project path>/bin/debug/<framework>
 
             // Act
             int result = await testSubject.InvokeFromStringAsync<int>(@"const value = require('./dummyReturnsValueModule.js');
@@ -1011,7 +1011,7 @@ module.exports = (callback) => {{
             dummyServices.Configure<OutOfProcessNodeJSServiceOptions>(options =>
             {
                 options.EnableFileWatching = true;
-                options.WatchPath = TEMP_WATCH_DIRECTORY;
+                options.WatchPath = _tempWatchDirectory;
                 // Graceful shutdown is true by default
             });
             HttpNodeJSService testSubject = CreateHttpNodeJSService(services: dummyServices);
@@ -1054,7 +1054,7 @@ module.exports = (callback) => {{
             dummyServices.Configure<OutOfProcessNodeJSServiceOptions>(options =>
             {
                 options.EnableFileWatching = true;
-                options.WatchPath = TEMP_WATCH_DIRECTORY;
+                options.WatchPath = _tempWatchDirectory;
                 options.WatchGracefulShutdown = false;
             });
             HttpNodeJSService testSubject = CreateHttpNodeJSService(resultStringBuilder, services: dummyServices);
@@ -1151,15 +1151,15 @@ module.exports = (callback) => {{
         private void RecreateWatchDirectory()
         {
             TryDeleteWatchDirectory();
-            Directory.CreateDirectory(TEMP_WATCH_DIRECTORY);
-            _tempWatchDirectoryUri = new Uri(TEMP_WATCH_DIRECTORY);
+            Directory.CreateDirectory(_tempWatchDirectory);
+            _tempWatchDirectoryUri = new Uri(_tempWatchDirectory);
         }
 
         private void TryDeleteWatchDirectory()
         {
             try
             {
-                Directory.Delete(TEMP_WATCH_DIRECTORY, true);
+                Directory.Delete(_tempWatchDirectory, true);
             }
             catch
             {

--- a/test/NodeJS/InvocationContentIntegrationTests.cs
+++ b/test/NodeJS/InvocationContentIntegrationTests.cs
@@ -59,7 +59,7 @@ namespace Jering.Javascript.NodeJS.Tests
             resultMemoryStream.Position = 0;
             using var resultReader = new StreamReader(resultMemoryStream);
             string result = resultReader.ReadToEnd();
-            Assert.Equal($"{{\"moduleSourceType\":{(int)dummyModuleSourceType}}}{Encoding.UTF8.GetString(InvocationContent.BOUNDARY_BYTES)}{dummyModuleSource}", result);
+            Assert.Equal($"{{\"moduleSourceType\":{(int)dummyModuleSourceType}}}{Encoding.UTF8.GetString(InvocationContent._boundaryBytes)}{dummyModuleSource}", result);
         }
 
         [Theory]

--- a/test/NodeJS/NodeJSProcessUnitTests.cs
+++ b/test/NodeJS/NodeJSProcessUnitTests.cs
@@ -17,8 +17,8 @@ namespace Jering.Javascript.NodeJS.Tests
     {
         private readonly MockRepository _mockRepository = new MockRepository(MockBehavior.Default);
         private const string DUMMY_LONG_RUNNING_SCRIPT_NAME = "dummyLongRunningScript.js";
-        private static readonly string PROJECT_PATH = Path.Combine(Directory.GetCurrentDirectory(), "../../../Javascript"); // Current directory is <test project path>/bin/debug/<framework>
-        private static readonly string DUMMY_LONG_RUNNING_SCRIPT = File.ReadAllText(Path.Combine(PROJECT_PATH, DUMMY_LONG_RUNNING_SCRIPT_NAME));
+        private static readonly string _projectPath = Path.Combine(Directory.GetCurrentDirectory(), "../../../Javascript"); // Current directory is <test project path>/bin/debug/<framework>
+        private static readonly string _dummyLongRunningScript = File.ReadAllText(Path.Combine(_projectPath, DUMMY_LONG_RUNNING_SCRIPT_NAME));
 
         [Fact]
         public void Constructor_ThrowsArgumentNullExceptionIfProcessIsNull()
@@ -374,7 +374,7 @@ namespace Jering.Javascript.NodeJS.Tests
         private Process CreateProcess()
         {
             var dummyNodeJSProcessFactory = new NodeJSProcessFactory(null);
-            ProcessStartInfo dummyProcessStartInfo = dummyNodeJSProcessFactory.CreateStartInfo(DUMMY_LONG_RUNNING_SCRIPT);
+            ProcessStartInfo dummyProcessStartInfo = dummyNodeJSProcessFactory.CreateStartInfo(_dummyLongRunningScript);
 
             return dummyNodeJSProcessFactory.CreateProcess(dummyProcessStartInfo);
         }

--- a/test/NodeJS/NodeJSServiceCollectionExtensionsUnitTests.cs
+++ b/test/NodeJS/NodeJSServiceCollectionExtensionsUnitTests.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using Xunit;
 
 namespace Jering.Javascript.NodeJS.Tests
@@ -20,36 +19,6 @@ namespace Jering.Javascript.NodeJS.Tests
             // Assert
             IServiceProvider serviceProvider = services.BuildServiceProvider();
             INodeJSService _ = serviceProvider.GetRequiredService<INodeJSService>(); // As long as this doesn't throw, the dependency graph is valid
-        }
-
-        [Theory]
-        [MemberData(nameof(IHttpClientServiceFactory_SetsTimeout_Data))]
-        public void IHttpClientServiceFactory_SetsTimeout(int dummyTimeoutMS, TimeSpan expectedTimeoutMS)
-        {
-            // Arrange
-            var services = new ServiceCollection();
-            services.AddNodeJS();
-            services.Configure<OutOfProcessNodeJSServiceOptions>(options => options.TimeoutMS = dummyTimeoutMS);
-            IServiceProvider serviceProvider = services.BuildServiceProvider();
-
-            // Act
-            var result = NodeJSServiceCollectionExtensions.IHttpClientServiceFactory(serviceProvider) as HttpClientService;
-
-            // Assert
-            Assert.NotNull(result);
-            Assert.Equal(expectedTimeoutMS, result.Timeout);
-        }
-
-        public static IEnumerable<object[]> IHttpClientServiceFactory_SetsTimeout_Data()
-        {
-            return new object[][]
-            {
-                // -1 == infinite
-                new object[]{ -1, Timeout.InfiniteTimeSpan},
-                // All other values == value + 1000
-                new object[]{ 0, TimeSpan.FromMilliseconds(1000)},
-                new object[]{ 1000, TimeSpan.FromMilliseconds(2000)}
-            };
         }
 
         [Theory]

--- a/test/NodeJS/OutOfProcessNodeJSServiceUnitTests.cs
+++ b/test/NodeJS/OutOfProcessNodeJSServiceUnitTests.cs
@@ -53,7 +53,7 @@ namespace Jering.Javascript.NodeJS.Tests
             const int dummyResult = 1;
             const string dummyModulePath = "dummyModulePath";
             const string dummyExportName = "dummyExportName";
-            var dummyArgs = new object[0];
+            object[] dummyArgs = Array.Empty<object>();
             var dummyCancellationToken = new CancellationToken();
             Mock<OutOfProcessNodeJSService> mockTestSubject = CreateMockOutOfProcessNodeJSService();
             mockTestSubject.CallBase = true;
@@ -83,7 +83,7 @@ namespace Jering.Javascript.NodeJS.Tests
             // Arrange
             const string dummyModulePath = "dummyModulePath";
             const string dummyExportName = "dummyExportName";
-            var dummyArgs = new object[0];
+            object[] dummyArgs = Array.Empty<object>();
             var dummyCancellationToken = new CancellationToken();
             Mock<OutOfProcessNodeJSService> mockTestSubject = CreateMockOutOfProcessNodeJSService();
             mockTestSubject.CallBase = true;
@@ -106,7 +106,7 @@ namespace Jering.Javascript.NodeJS.Tests
             const string dummyModuleString = "dummyModuleString";
             const string dummyNewCacheIdentifier = "dummyNewCacheIdentifier";
             const string dummyExportName = "dummyExportName";
-            var dummyArgs = new object[0];
+            object[] dummyArgs = Array.Empty<object>();
             var dummyCancellationToken = new CancellationToken();
             Mock<OutOfProcessNodeJSService> mockTestSubject = CreateMockOutOfProcessNodeJSService();
             mockTestSubject.CallBase = true;
@@ -137,7 +137,7 @@ namespace Jering.Javascript.NodeJS.Tests
             const string dummyModuleString = "dummyModuleString";
             const string dummyNewCacheIdentifier = "dummyNewCacheIdentifier";
             const string dummyExportName = "dummyExportName";
-            var dummyArgs = new object[0];
+            object[] dummyArgs = Array.Empty<object>();
             var dummyCancellationToken = new CancellationToken();
             Mock<OutOfProcessNodeJSService> mockTestSubject = CreateMockOutOfProcessNodeJSService();
             mockTestSubject.CallBase = true;
@@ -173,7 +173,7 @@ namespace Jering.Javascript.NodeJS.Tests
             const int dummyResult = 1;
             const string dummyCacheIdentifier = "dummyCacheIdentifier";
             const string dummyExportName = "dummyExportName";
-            var dummyArgs = new object[0];
+            object[] dummyArgs = Array.Empty<object>();
             var dummyCancellationToken = new CancellationToken();
             Mock<OutOfProcessNodeJSService> mockTestSubject = CreateMockOutOfProcessNodeJSService();
             mockTestSubject.CallBase = true;
@@ -197,7 +197,7 @@ namespace Jering.Javascript.NodeJS.Tests
             const string dummyCacheIdentifier = "dummyCacheIdentifier";
             const string dummyExportName = "dummyExportName";
             const string dummyModule = "dummyModule";
-            var dummyArgs = new object[0];
+            object[] dummyArgs = Array.Empty<object>();
             var dummyCancellationToken = new CancellationToken();
             Mock<OutOfProcessNodeJSService> mockTestSubject = CreateMockOutOfProcessNodeJSService();
             mockTestSubject.CallBase = true;
@@ -231,7 +231,7 @@ namespace Jering.Javascript.NodeJS.Tests
             Func<string> dummyFactory = () => "dummyModule";
             const string dummyCacheIdentifier = "dummyCacheIdentifier";
             const string dummyExportName = "dummyExportName";
-            var dummyArgs = new object[0];
+            object[] dummyArgs = Array.Empty<object>();
             var dummyCancellationToken = new CancellationToken();
             Mock<OutOfProcessNodeJSService> mockTestSubject = CreateMockOutOfProcessNodeJSService();
             mockTestSubject.CallBase = true;
@@ -254,7 +254,7 @@ namespace Jering.Javascript.NodeJS.Tests
             var dummyModuleStream = new MemoryStream();
             const string dummyNewCacheIdentifier = "dummyNewCacheIdentifier";
             const string dummyExportName = "dummyExportName";
-            var dummyArgs = new object[0];
+            object[] dummyArgs = Array.Empty<object>();
             var dummyCancellationToken = new CancellationToken();
             Mock<OutOfProcessNodeJSService> mockTestSubject = CreateMockOutOfProcessNodeJSService();
             mockTestSubject.CallBase = true;
@@ -285,7 +285,7 @@ namespace Jering.Javascript.NodeJS.Tests
             var dummyModuleStream = new MemoryStream();
             const string dummyNewCacheIdentifier = "dummyNewCacheIdentifier";
             const string dummyExportName = "dummyExportName";
-            var dummyArgs = new object[0];
+            object[] dummyArgs = Array.Empty<object>();
             var dummyCancellationToken = new CancellationToken();
             Mock<OutOfProcessNodeJSService> mockTestSubject = CreateMockOutOfProcessNodeJSService();
             mockTestSubject.CallBase = true;
@@ -321,7 +321,7 @@ namespace Jering.Javascript.NodeJS.Tests
             const int dummyResult = 1;
             const string dummyCacheIdentifier = "dummyCacheIdentifier";
             const string dummyExportName = "dummyExportName";
-            var dummyArgs = new object[0];
+            object[] dummyArgs = Array.Empty<object>();
             var dummyCancellationToken = new CancellationToken();
             Mock<OutOfProcessNodeJSService> mockTestSubject = CreateMockOutOfProcessNodeJSService();
             mockTestSubject.CallBase = true;
@@ -345,7 +345,7 @@ namespace Jering.Javascript.NodeJS.Tests
             const string dummyCacheIdentifier = "dummyCacheIdentifier";
             const string dummyExportName = "dummyExportName";
             var dummyModule = new MemoryStream();
-            var dummyArgs = new object[0];
+            object[] dummyArgs = Array.Empty<object>();
             var dummyCancellationToken = new CancellationToken();
             Mock<OutOfProcessNodeJSService> mockTestSubject = CreateMockOutOfProcessNodeJSService();
             mockTestSubject.CallBase = true;
@@ -379,7 +379,7 @@ namespace Jering.Javascript.NodeJS.Tests
             Func<Stream> dummyFactory = () => new MemoryStream();
             const string dummyCacheIdentifier = "dummyCacheIdentifier";
             const string dummyExportName = "dummyExportName";
-            var dummyArgs = new object[0];
+            object[] dummyArgs = Array.Empty<object>();
             var dummyCancellationToken = new CancellationToken();
             Mock<OutOfProcessNodeJSService> mockTestSubject = CreateMockOutOfProcessNodeJSService();
             mockTestSubject.CallBase = true;
@@ -400,7 +400,7 @@ namespace Jering.Javascript.NodeJS.Tests
             const int dummyResult = 1;
             const string dummyModuleCacheIdentifier = "dummyModuleCacheIdentifier";
             const string dummyExportName = "dummyExportName";
-            var dummyArgs = new object[0];
+            object[] dummyArgs = Array.Empty<object>();
             var dummyCancellationToken = new CancellationToken();
             Mock<OutOfProcessNodeJSService> mockTestSubject = CreateMockOutOfProcessNodeJSService();
             mockTestSubject.CallBase = true;
@@ -431,7 +431,7 @@ namespace Jering.Javascript.NodeJS.Tests
             // Arrange
             const string dummyModuleCacheIdentifier = "dummyModuleCacheIdentifier";
             const string dummyExportName = "dummyExportName";
-            var dummyArgs = new object[0];
+            object[] dummyArgs = Array.Empty<object>();
             var dummyCancellationToken = new CancellationToken();
             Mock<OutOfProcessNodeJSService> mockTestSubject = CreateMockOutOfProcessNodeJSService();
             mockTestSubject.CallBase = true;

--- a/test/NodeJS/OutOfProcessNodeJSServiceUnitTests.cs
+++ b/test/NodeJS/OutOfProcessNodeJSServiceUnitTests.cs
@@ -1226,7 +1226,25 @@ namespace Jering.Javascript.NodeJS.Tests
             Assert.Equal(logResult, $"{nameof(LogLevel.Error)}: {dummyMessage}\n", ignoreLineEndingDifferences: true);
         }
 
-        [Fact(Timeout = TIMEOUT_MS)] // Calls ConnectIfNotConnected so threading involved
+        [Fact]
+        public void FileChangedHandler_LogsChangedFileAndMovesToNewProcess()
+        {
+            // Arrange
+            const string dummyPath = "dummyPath";
+            var loggerStringBuilder = new StringBuilder();
+            Mock<OutOfProcessNodeJSService> mockTestSubject = CreateMockOutOfProcessNodeJSService(loggerStringBuilder: loggerStringBuilder, logLevel: LogLevel.Information);
+            mockTestSubject.CallBase = true;
+            mockTestSubject.Setup(t => t.MoveToNewProcess(true));
+
+            // Act
+            mockTestSubject.Object.FileChangedHandler(dummyPath);
+
+            // Assert
+            mockTestSubject.Verify(t => t.MoveToNewProcess(true), times: Times.Once);
+            Assert.Contains(string.Format(Strings.LogInformation_FileChangedMovingtoNewNodeJSProcess, dummyPath), loggerStringBuilder.ToString());
+        }
+
+        [Fact]
         public void MoveToNewProcess_DoesNothingIfConnectingLockNotAquiredAndReswapIfJustConnectedIsFalse()
         {
             // Arrange


### PR DESCRIPTION
- `HttpNodeJSService` now logs the port it connects to Node.js on. This'll help with troubleshooting socket permission issues.
- Added `OutOfProcessNodeJSServiceOptions.NumProcessRetries`. Instead of just retrying invocations in the same process, invocations are also retried in a new process by default.