### PR TITLE
Allow HttpResponseMessage in invoke result, and response control in c…

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,13 @@ This project uses [semantic versioning](http://semver.org/spec/v2.0.0.html). Ref
 *[Semantic Versioning in Practice](https://www.jering.tech/articles/semantic-versioning-in-practice)*
 for an overview of semantic versioning.
 
-## [Unreleased](https://github.com/JeringTech/Javascript.NodeJS/compare/7.0.0-beta.2...HEAD)
+## [Unreleased](https://github.com/JeringTech/Javascript.NodeJS/compare/7.0.0-beta.3...HEAD)
+
+## [7.0.0-beta.3](https://github.com/JeringTech/Javascript.NodeJS/compare/7.0.0-beta.2...7.0.0-beta.3) - Feb 14, 2023
+### Additions
+- Added `HttpResponseMessage` as a possible invocation result. ([#157](https://github.com/JeringTech/Javascript.NodeJS/pull/157)).
+- Added a `responseAction` parameter to the [Javascript callback](https://github.com/JeringTech/Javascript.NodeJS#invoking-javascript). This action can be used to modify an invocation's
+HTTP response before it is sent from Node.js to the .Net process. ([#157](https://github.com/JeringTech/Javascript.NodeJS/pull/157)).
 
 ## [7.0.0-beta.2](https://github.com/JeringTech/Javascript.NodeJS/compare/7.0.0-beta.1...7.0.0-beta.2) - Jan 19, 2023
 ### Additions

--- a/src/NodeJS/Javascript/Servers/OutOfProcess/Http/Http11Server.ts
+++ b/src/NodeJS/Javascript/Servers/OutOfProcess/Http/Http11Server.ts
@@ -1,6 +1,4 @@
 // The typings for module are incomplete and can't be augmented, so import as any.
-import {Http2ServerRequest, Http2ServerResponse} from "http2";
-
 const Module = require('module');
 import * as http from 'http';
 import { AddressInfo, Socket } from 'net';

--- a/src/NodeJS/Javascript/Servers/OutOfProcess/Http/Http11Server.ts
+++ b/src/NodeJS/Javascript/Servers/OutOfProcess/Http/Http11Server.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import * as stream from 'stream';
 import InvocationRequest from '../../../InvocationData/InvocationRequest';
 import ModuleSourceType from '../../../InvocationData/ModuleSourceType';
-import { getTempIdentifier, respondWithError, setup, IHttpResponse } from './Shared';
+import { getTempIdentifier, respondWithError, setup } from './Shared';
 
 // Setup
 const [args, projectDir, moduleResolutionPaths] = setup();
@@ -154,7 +154,7 @@ function serverOnRequestListener(req: http.IncomingMessage, res: http.ServerResp
                 }
 
                 let callbackCalled = false;
-                const callback = (error: Error | string, result: any, resAction?: (response: IHttpResponse) => boolean) => {
+                const callback = (error: Error | string, result: any, responseAction?: (response: http.ServerResponse) => boolean) => {
                     if (callbackCalled) {
                         return;
                     }
@@ -163,8 +163,8 @@ function serverOnRequestListener(req: http.IncomingMessage, res: http.ServerResp
                     if (error != null) {
                         respondWithError(res, error);
                     }
-                    
-                    if (resAction?.(res)) {
+
+                    if (responseAction?.(res)) {
                         return;
                     }
 

--- a/src/NodeJS/Javascript/Servers/OutOfProcess/Http/Http11Server.ts
+++ b/src/NodeJS/Javascript/Servers/OutOfProcess/Http/Http11Server.ts
@@ -154,7 +154,7 @@ function serverOnRequestListener(req: http.IncomingMessage, res: http.ServerResp
                 }
 
                 let callbackCalled = false;
-                const callback = (error: Error | string, result: any, resAction?: (request: IHttpResponse) => boolean) => {
+                const callback = (error: Error | string, result: any, resAction?: (response: IHttpResponse) => boolean) => {
                     if (callbackCalled) {
                         return;
                     }

--- a/src/NodeJS/Javascript/Servers/OutOfProcess/Http/Http20Server.ts
+++ b/src/NodeJS/Javascript/Servers/OutOfProcess/Http/Http20Server.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import * as stream from 'stream';
 import InvocationRequest from '../../../InvocationData/InvocationRequest';
 import ModuleSourceType from '../../../InvocationData/ModuleSourceType';
-import {getTempIdentifier, IHttpResponse, respondWithError, setup} from './Shared';
+import { getTempIdentifier, respondWithError, setup } from './Shared';
 
 // Setup
 const [args, projectDir, moduleResolutionPaths] = setup();
@@ -140,7 +140,7 @@ function serverOnRequestListener(req: http2.Http2ServerRequest, res: http2.Http2
                 }
 
                 let callbackCalled = false;
-                const callback = (error: Error | string, result: any, resAction?: (response: IHttpResponse) => boolean) => {
+                const callback = (error: Error | string, result: any, responseAction?: (response: http2.Http2ServerResponse) => boolean) => {
                     if (callbackCalled) {
                         return;
                     }
@@ -151,10 +151,10 @@ function serverOnRequestListener(req: http2.Http2ServerRequest, res: http2.Http2
                         return;
                     }
 
-                    if (resAction?.(res)) {
+                    if (responseAction?.(res)) {
                         return;
                     }
-                    
+
                     if (result instanceof stream.Readable) {
                         // By default, res is ended when result ends - https://nodejs.org/api/stream.html#stream_readable_pipe_destination_options
                         result.pipe(res.stream);

--- a/src/NodeJS/Javascript/Servers/OutOfProcess/Http/Http20Server.ts
+++ b/src/NodeJS/Javascript/Servers/OutOfProcess/Http/Http20Server.ts
@@ -140,7 +140,7 @@ function serverOnRequestListener(req: http2.Http2ServerRequest, res: http2.Http2
                 }
 
                 let callbackCalled = false;
-                const callback = (error: Error | string, result: any, resAction?: (request: IHttpResponse) => boolean) => {
+                const callback = (error: Error | string, result: any, resAction?: (response: IHttpResponse) => boolean) => {
                     if (callbackCalled) {
                         return;
                     }

--- a/src/NodeJS/Javascript/Servers/OutOfProcess/Http/Shared.ts
+++ b/src/NodeJS/Javascript/Servers/OutOfProcess/Http/Shared.ts
@@ -1,4 +1,5 @@
 ﻿const path = require("path");
+import * as stream from 'stream';
 import * as http from 'http';
 import * as http2 from 'http2';
 import InvocationRequest from "../../../InvocationData/InvocationRequest";
@@ -165,4 +166,9 @@ function demarcateMessageEndings(outputStream: NodeJS.WritableStream) {
 
         origWriteFunction.apply(this, arguments);
     };
+}
+export interface IHttpResponse extends stream.Writable {
+    setHeader(name: string, value: string | string[]): void;
+    writeHead(statusCode: number, headers?: http.OutgoingHttpHeaders): this;
+    writeHead(statusCode: number, statusMessage: string, headers?: http.OutgoingHttpHeaders): this;
 }

--- a/src/NodeJS/Javascript/Servers/OutOfProcess/Http/Shared.ts
+++ b/src/NodeJS/Javascript/Servers/OutOfProcess/Http/Shared.ts
@@ -167,8 +167,3 @@ function demarcateMessageEndings(outputStream: NodeJS.WritableStream) {
         origWriteFunction.apply(this, arguments);
     };
 }
-export interface IHttpResponse extends stream.Writable {
-    setHeader(name: string, value: string | string[]): void;
-    writeHead(statusCode: number, headers?: http.OutgoingHttpHeaders): this;
-    writeHead(statusCode: number, statusMessage: string, headers?: http.OutgoingHttpHeaders): this;
-}

--- a/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpNodeJSService.cs
+++ b/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpNodeJSService.cs
@@ -157,6 +157,10 @@ namespace Jering.Javascript.NodeJS
 #endif
                         return (true, (T)(object)stream); // User's reponsibility to handle disposal
                     }
+                    else if (typeof(T) == typeof(HttpResponseMessage))
+                    {
+                        return (true, (T)(object)httpResponseMessage); 
+                    }
                     else
                     {
 #if NET5_0_OR_GREATER

--- a/test/NodeJS/Helpers/AssertHelper.cs
+++ b/test/NodeJS/Helpers/AssertHelper.cs
@@ -1,0 +1,13 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Xunit;
+
+namespace Jering.Javascript.NodeJS.Tests
+{
+    public static class AssertHelper
+    {
+        public static void NotNull([NotNull] object? obj)
+        {
+            Assert.NotNull(obj);
+        }
+    }
+}

--- a/test/NodeJS/Javascript/dummyReturnResAction.mjs
+++ b/test/NodeJS/Javascript/dummyReturnResAction.mjs
@@ -1,0 +1,17 @@
+function resActionWithHeader(callback, header, headerValue, result) {
+    callback(null, result, (res) => {
+        res.setHeader(header, headerValue);
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        return false;
+    });
+}
+
+function resActionWithHeaderAndReturn(callback, header, headerValue, result) {
+    callback(null, null, (res) => {
+        res.setHeader(header, headerValue);
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end(result)
+    });
+}
+
+export { resActionWithHeader, resActionWithHeaderAndReturn };

--- a/test/NodeJS/Javascript/dummyReturnResponseAction.mjs
+++ b/test/NodeJS/Javascript/dummyReturnResponseAction.mjs
@@ -1,4 +1,4 @@
-function resActionWithHeader(callback, header, headerValue, result) {
+function responseActionWithHeader(callback, header, headerValue, result) {
     callback(null, result, (res) => {
         res.setHeader(header, headerValue);
         res.writeHead(200, { 'Content-Type': 'text/plain' });
@@ -6,7 +6,7 @@ function resActionWithHeader(callback, header, headerValue, result) {
     });
 }
 
-function resActionWithHeaderAndReturn(callback, header, headerValue, result) {
+function responseActionWithHeaderAndReturn(callback, header, headerValue, result) {
     callback(null, null, (res) => {
         res.setHeader(header, headerValue);
         res.writeHead(200, { 'Content-Type': 'text/plain' });
@@ -14,4 +14,4 @@ function resActionWithHeaderAndReturn(callback, header, headerValue, result) {
     });
 }
 
-export { resActionWithHeader, resActionWithHeaderAndReturn };
+export { responseActionWithHeader, responseActionWithHeaderAndReturn };

--- a/test/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpNodeJSServiceIntegrationTests.cs
+++ b/test/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpNodeJSServiceIntegrationTests.cs
@@ -32,7 +32,7 @@ namespace Jering.Javascript.NodeJS.Tests
         private const string DUMMY_SINGLE_FUNCTION_EXPORT_ECMA_SCRIPT_MODULE_FILE = "dummySingleFunctionExportECMAScriptModule.mjs";
         private const string DUMMY_MULTIPLE_FUNCTION_EXPORT_ECMA_SCRIPT_MODULE_FILE = "dummyMultipleFunctionExportECMAScriptModule.mjs";
         private const string DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE_FILE = "dummyExportsMultipleFunctionsModule.js";
-        private const string DUMMY_RETURN_RES_ACTION_FILE = "dummyReturnResAction.mjs";
+        private const string DUMMY_RETURN_RESPONSE_ACTION_FILE = "dummyReturnResponseAction.mjs";
         private const string DUMMY_CACHE_IDENTIFIER = "dummyCacheIdentifier";
         private static readonly string _projectPath = Path.Combine(Directory.GetCurrentDirectory(), "../../../Javascript"); // Current directory is <test project path>/bin/debug/<framework>
         private static readonly string _dummyReturnsArgModule = File.ReadAllText(Path.Combine(_projectPath, DUMMY_RETURNS_ARG_MODULE_FILE));
@@ -228,12 +228,14 @@ namespace Jering.Javascript.NodeJS.Tests
             const string Content = "success-content";
 
             // Act
-            var result1 = await testSubject.InvokeFromFileAsync<HttpResponseMessage>(DUMMY_RETURN_RES_ACTION_FILE, "resActionWithHeader", new object[] { HeaderName, HeaderValue, Content }).ConfigureAwait(false);
-            var result2 = await testSubject.InvokeFromFileAsync<HttpResponseMessage>(DUMMY_RETURN_RES_ACTION_FILE, "resActionWithHeaderAndReturn", new object[] { HeaderName, HeaderValue, Content }).ConfigureAwait(false);
-            
+            HttpResponseMessage? result1 = await testSubject.InvokeFromFileAsync<HttpResponseMessage>(DUMMY_RETURN_RESPONSE_ACTION_FILE, "responseActionWithHeader", new object[] { HeaderName, HeaderValue, Content }).ConfigureAwait(false);
+            HttpResponseMessage? result2 = await testSubject.InvokeFromFileAsync<HttpResponseMessage>(DUMMY_RETURN_RESPONSE_ACTION_FILE, "responseActionWithHeaderAndReturn", new object[] { HeaderName, HeaderValue, Content }).ConfigureAwait(false);
+
             // Assert
+            AssertHelper.NotNull(result1);
             Assert.Equal(Content, await result1.Content.ReadAsStringAsync().ConfigureAwait(false));
             Assert.Equal(HeaderValue, result1.Headers.GetValues(HeaderName).First());
+            AssertHelper.NotNull(result2);
             Assert.Equal(Content, await result2.Content.ReadAsStringAsync().ConfigureAwait(false));
             Assert.Equal(HeaderValue, result2.Headers.GetValues(HeaderName).First());
         }

--- a/test/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpNodeJSServiceIntegrationTests.cs
+++ b/test/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpNodeJSServiceIntegrationTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -31,6 +32,7 @@ namespace Jering.Javascript.NodeJS.Tests
         private const string DUMMY_SINGLE_FUNCTION_EXPORT_ECMA_SCRIPT_MODULE_FILE = "dummySingleFunctionExportECMAScriptModule.mjs";
         private const string DUMMY_MULTIPLE_FUNCTION_EXPORT_ECMA_SCRIPT_MODULE_FILE = "dummyMultipleFunctionExportECMAScriptModule.mjs";
         private const string DUMMY_EXPORTS_MULTIPLE_FUNCTIONS_MODULE_FILE = "dummyExportsMultipleFunctionsModule.js";
+        private const string DUMMY_RETURN_RES_ACTION_FILE = "dummyReturnResAction.mjs";
         private const string DUMMY_CACHE_IDENTIFIER = "dummyCacheIdentifier";
         private static readonly string _projectPath = Path.Combine(Directory.GetCurrentDirectory(), "../../../Javascript"); // Current directory is <test project path>/bin/debug/<framework>
         private static readonly string _dummyReturnsArgModule = File.ReadAllText(Path.Combine(_projectPath, DUMMY_RETURNS_ARG_MODULE_FILE));
@@ -213,6 +215,27 @@ namespace Jering.Javascript.NodeJS.Tests
             // Assert
             Assert.Equal(-1, result1);
             Assert.Equal(3, result2);
+        }
+        
+        [Fact(Timeout = TIMEOUT_MS)]
+        public async void InvokeFromFileAsync_ResActionShouldReturnHeadersAndContentInResponseMessage()
+        {
+            // Arrange
+            HttpNodeJSService testSubject = CreateHttpNodeJSService(projectPath: _projectPath);
+            
+            const string HeaderName = "success-header";
+            const string HeaderValue = "success-value";
+            const string Content = "success-content";
+
+            // Act
+            var result1 = await testSubject.InvokeFromFileAsync<HttpResponseMessage>(DUMMY_RETURN_RES_ACTION_FILE, "resActionWithHeader", new object[] { HeaderName, HeaderValue, Content }).ConfigureAwait(false);
+            var result2 = await testSubject.InvokeFromFileAsync<HttpResponseMessage>(DUMMY_RETURN_RES_ACTION_FILE, "resActionWithHeaderAndReturn", new object[] { HeaderName, HeaderValue, Content }).ConfigureAwait(false);
+            
+            // Assert
+            Assert.Equal(Content, await result1.Content.ReadAsStringAsync().ConfigureAwait(false));
+            Assert.Equal(HeaderValue, result1.Headers.GetValues(HeaderName).First());
+            Assert.Equal(Content, await result2.Content.ReadAsStringAsync().ConfigureAwait(false));
+            Assert.Equal(HeaderValue, result2.Headers.GetValues(HeaderName).First());
         }
 
         [Fact(Timeout = TIMEOUT_MS)]


### PR DESCRIPTION
I am working on a new version of [NodeReact](https://github.com/DaniilSokolyuk/NodeReact.NET/pull/8) and i encountered several problems
1) I need to proxy the response of a node to a user, or effectively buffer it, for this I need `HttpResponseMessage.Content.CopyTo` instead `httpResponseMessage.Content.ReadAsStreamAsync.CopyTo`
2) Node always responds with text (rendered html) , sometimes there are very big React components and JSON serialization and deserialization makes a big performance impact, but also sometimes I have to return metadata, for this I need to return the headers from Node function
3) In the new version of ReactJS it is better to use [renderToPipeableStream](https://beta.reactjs.org/reference/react-dom/server/renderToPipeableStream) but it returns pipe - a function that takes stream.Writable, for this I added this feature to the callback as well 