### PR TITLE
Unit test fixes

### DIFF
--- a/test/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpNodeJSPoolServiceIntegrationTests.cs
+++ b/test/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpNodeJSPoolServiceIntegrationTests.cs
@@ -94,12 +94,13 @@ namespace Jering.Javascript.NodeJS.Tests
             const int dummyNumProcesses = 5;
             Uri tempWatchDirectoryUri = CreateWatchDirectoryUri();
             // Create initial module
-            string dummylongRunningTriggerPath = new Uri(tempWatchDirectoryUri, "dummyTriggerFile").LocalPath;
+            string dummylongRunningTriggerPath = new Uri(tempWatchDirectoryUri, "dummyTriggerFile").LocalPath; // Use LocalPath instead of AbsolutePath, the latter performs URL encoding, which results in paths that are invalid for local use
 #if NET461
             File.WriteAllText(dummylongRunningTriggerPath, string.Empty); // fs.watch returns immediately if path to watch doesn't exist
 #else
             await File.WriteAllTextAsync(dummylongRunningTriggerPath, string.Empty).ConfigureAwait(false); // fs.watch returns immediately if path to watch doesn't exist
 #endif
+            // JavascriptEncode.Default.Encode encodes a string so that it can be used as a string literal in Javascript
             string dummyInitialModule = $@"module.exports = {{
     getPid: (callback) => callback(null, process.pid),
     longRunning: (callback) => {{

--- a/test/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpNodeJSPoolServiceIntegrationTests.cs
+++ b/test/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpNodeJSPoolServiceIntegrationTests.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -93,7 +94,7 @@ namespace Jering.Javascript.NodeJS.Tests
             const int dummyNumProcesses = 5;
             Uri tempWatchDirectoryUri = CreateWatchDirectoryUri();
             // Create initial module
-            string dummylongRunningTriggerPath = new Uri(tempWatchDirectoryUri, "dummyTriggerFile").AbsolutePath; // fs.watch can't deal with backslashes in paths
+            string dummylongRunningTriggerPath = new Uri(tempWatchDirectoryUri, "dummyTriggerFile").LocalPath;
 #if NET461
             File.WriteAllText(dummylongRunningTriggerPath, string.Empty); // fs.watch returns immediately if path to watch doesn't exist
 #else
@@ -102,7 +103,7 @@ namespace Jering.Javascript.NodeJS.Tests
             string dummyInitialModule = $@"module.exports = {{
     getPid: (callback) => callback(null, process.pid),
     longRunning: (callback) => {{
-        fs.watch('{dummylongRunningTriggerPath}', 
+        fs.watch('{JavaScriptEncoder.Default.Encode(dummylongRunningTriggerPath)}', 
             null, 
             () => {{
                 callback(null, process.pid);
@@ -110,7 +111,7 @@ namespace Jering.Javascript.NodeJS.Tests
         );
     }}
 }}";
-            string dummyModuleFilePath = new Uri(tempWatchDirectoryUri, "dummyModule.js").AbsolutePath;
+            string dummyModuleFilePath = new Uri(tempWatchDirectoryUri, "dummyModule.js").LocalPath;
 #if NET461
             File.WriteAllText(dummyModuleFilePath, dummyInitialModule);
 #else
@@ -194,7 +195,7 @@ namespace Jering.Javascript.NodeJS.Tests
     getPid: (callback) => callback(null, process.pid),
     longRunning: (callback) => setInterval(() => { /* Do nothing */ }, 1000)
 }";
-            string dummyModuleFilePath = new Uri(CreateWatchDirectoryUri(), "dummyModule.js").AbsolutePath;
+            string dummyModuleFilePath = new Uri(CreateWatchDirectoryUri(), "dummyModule.js").LocalPath;
 #if NET461
             File.WriteAllText(dummyModuleFilePath, dummyInitialModule);
 #else

--- a/test/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpNodeJSServiceIntegrationTests.cs
+++ b/test/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpNodeJSServiceIntegrationTests.cs
@@ -1107,12 +1107,13 @@ module.exports = (callback) => {{
             // Arrange
             Uri tempWatchDirectoryUri = CreateWatchDirectoryUri();
             // Create initial module
-            string dummylongRunningTriggerPath = new Uri(tempWatchDirectoryUri, "dummyTriggerFile").LocalPath; // fs.watch can't deal with backslashes in paths
+            string dummylongRunningTriggerPath = new Uri(tempWatchDirectoryUri, "dummyTriggerFile").LocalPath; // Use LocalPath instead of AbsolutePath, the latter performs URL encoding, which results in paths that are invalid for local use
 #if NET461
             File.WriteAllText(dummylongRunningTriggerPath, string.Empty); // fs.watch returns immediately if path to watch doesn't exist
 #else
             await File.WriteAllTextAsync(dummylongRunningTriggerPath, string.Empty).ConfigureAwait(false); // fs.watch returns immediately if path to watch doesn't exist
 #endif
+            // JavascriptEncode.Default.Encode encodes a string so that it can be used as a string literal in Javascript
             string dummyInitialModule = $@"module.exports = {{
     getPid: (callback) => callback(null, process.pid),
     longRunning: (callback) => {{

--- a/test/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpNodeJSServiceIntegrationTests.cs
+++ b/test/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpNodeJSServiceIntegrationTests.cs
@@ -10,6 +10,7 @@ using System.Net;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -1106,7 +1107,7 @@ module.exports = (callback) => {{
             // Arrange
             Uri tempWatchDirectoryUri = CreateWatchDirectoryUri();
             // Create initial module
-            string dummylongRunningTriggerPath = new Uri(tempWatchDirectoryUri, "dummyTriggerFile").AbsolutePath; // fs.watch can't deal with backslashes in paths
+            string dummylongRunningTriggerPath = new Uri(tempWatchDirectoryUri, "dummyTriggerFile").LocalPath; // fs.watch can't deal with backslashes in paths
 #if NET461
             File.WriteAllText(dummylongRunningTriggerPath, string.Empty); // fs.watch returns immediately if path to watch doesn't exist
 #else
@@ -1115,7 +1116,7 @@ module.exports = (callback) => {{
             string dummyInitialModule = $@"module.exports = {{
     getPid: (callback) => callback(null, process.pid),
     longRunning: (callback) => {{
-        fs.watch('{dummylongRunningTriggerPath}', 
+        fs.watch('{JavaScriptEncoder.Default.Encode(dummylongRunningTriggerPath)}', 
             null, 
             () => {{
                 callback(null, process.pid);
@@ -1123,7 +1124,7 @@ module.exports = (callback) => {{
         );
     }}
 }}";
-            string dummyModuleFilePath = new Uri(tempWatchDirectoryUri, "dummyModule.js").AbsolutePath;
+            string dummyModuleFilePath = new Uri(tempWatchDirectoryUri, "dummyModule.js").LocalPath;
 #if NET461
             File.WriteAllText(dummyModuleFilePath, dummyInitialModule);
 #else
@@ -1175,7 +1176,7 @@ module.exports = (callback) => {{
     getPid: (callback) => callback(null, process.pid),
     longRunning: (callback) => setInterval(() => { /* Do nothing */ }, 1000)
 }";
-            string dummyModuleFilePath = new Uri(CreateWatchDirectoryUri(), "dummyModule.js").AbsolutePath;
+            string dummyModuleFilePath = new Uri(CreateWatchDirectoryUri(), "dummyModule.js").LocalPath;
 #if NET461
             File.WriteAllText(dummyModuleFilePath, dummyInitialModule);
 #else

--- a/test/NodeJS/NodeJSServiceImplementations/OutOfProcess/OutOfProcessNodeJSServiceUnitTests.cs
+++ b/test/NodeJS/NodeJSServiceImplementations/OutOfProcess/OutOfProcessNodeJSServiceUnitTests.cs
@@ -462,7 +462,7 @@ namespace Jering.Javascript.NodeJS.Tests
             mockTestSubject.Object.Dispose();
             ObjectDisposedException result = await Assert.
                 ThrowsAsync<ObjectDisposedException>(async () => await mockTestSubject.Object.TryInvokeCoreAsync<string>(new InvocationRequest(ModuleSourceType.String, "dummyModuleSource"), CancellationToken.None).ConfigureAwait(false)).ConfigureAwait(false);
-            Assert.Equal($"Cannot access a disposed object.\nObject name: '{nameof(OutOfProcessNodeJSService)}'.", result.Message, ignoreLineEndingDifferences: true);
+            Assert.Contains($"{nameof(OutOfProcessNodeJSService)}", result.Message);
         }
 
         [Fact]


### PR DESCRIPTION
The existing unit tests partially failed on my system due to two reasons:
1. My user name contains a space, which causes the "AbsolutePath" property to contain a "%20" and the file writes to fail
2. As I'm working on a non-english OS, my exception messages are not in english, which caused one unit test to fail

This PR fixes both issues making future contributions more easy.